### PR TITLE
fix(deps): bump rand to 0.10.1 to address RUSTSEC-2026-0097

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,9 +1263,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom",


### PR DESCRIPTION
## Summary

- `cargo deny` (the `lint` job) is failing on `main` and on every open dependabot PR with [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097): an unsoundness in `rand` 0.10.0 triggered when a custom `log` logger reads from `rand::rng()`.
- Run `cargo update -p rand` to bump the locked version from 0.10.0 → 0.10.1, which is the advisory's recommended fix.
- Only `Cargo.lock` is touched; no source changes.

This unblocks PRs #274, #275, #276 which are otherwise green but cannot merge while `lint` fails.

## Test plan

- [x] `cargo deny check advisories` → `advisories ok`
- [x] `cargo check` passes
- [ ] Wait for CI (`lint` + `check` matrix) to go green