### PR TITLE
fix(docker): declare cross-compile targets in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.94.0"
 components = ["clippy", "rustfmt"]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
## Summary

- The Docker `build-and-publish` workflow has been failing on the arm64 cross-compile step since rust `1.94.0` got a new point release (2026-03-05).
- Root cause: the Dockerfile installs `aarch64-unknown-linux-gnu` via `rustup target add`, but once `COPY . .` brings `rust-toolchain.toml` into the build context, the next `cargo` call triggers a rustup channel sync. Because `targets` isn't declared in `rust-toolchain.toml`, the previously added aarch64 target is dropped, and the build fails with `error[E0463]: can't find crate for core`.
- Fix: declare both targets in `rust-toolchain.toml` so rustup keeps them across syncs.

## Verification

Reproduced and confirmed the fix locally inside `rust:1.94-bookworm` (matching the Dockerfile base):

| Step | aarch64 installed? |
| --- | --- |
| After `rustup target add aarch64-unknown-linux-gnu` | yes |
| After rustup sync triggered by current `rust-toolchain.toml` (no `targets`) | no — bug reproduced |
| After rustup sync triggered by patched `rust-toolchain.toml` (with `targets`) | yes — fix verified |

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, tag-triggered Docker workflow (`build-and-publish`) succeeds for `linux/amd64` and `linux/arm64`