### PR TITLE
perf(scan): skip reading image dimensions during the initial scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,6 @@ dependencies = [
  "chrono",
  "clap",
  "http",
- "imsz",
  "parking_lot",
  "rand",
  "rayon",
@@ -915,12 +914,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "imsz"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396dda16a82727ec2d14aabc1167832bb823d849c54a246ca0cff6cfb7bc697c"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ bcrypt = "0.19.1"
 chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 http = "1.4.1"
-imsz = "0.4.1"
 parking_lot = "0.12.1"
 rand = "0.10.0"
 rayon = "1.12.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use handlers::{
     Healthz, healthz_route, index_route, rescan_books_route, show_book_route, show_page_route,
     shuffle_book_route, shuffle_route,
 };
-pub use models::{Book, BookScan, Dimension, Page, scan_books};
+pub use models::{Book, BookScan, Page, scan_books};
 pub use state::AppState;
 
 pub const VERSION: &str = env!("APP_VERSION");

--- a/src/models/book.rs
+++ b/src/models/book.rs
@@ -1,27 +1,10 @@
 use std::path;
 
 use anyhow::{Context, bail};
-use imsz::ImInfo;
 use tracing::{Span, trace_span};
 
 use super::ids::hash_string;
 use super::scan::scan_pages;
-
-/// Image dimensions
-#[derive(Clone, Debug)]
-pub struct Dimension {
-    pub height: u64,
-    pub width: u64,
-}
-
-impl From<&ImInfo> for Dimension {
-    fn from(value: &ImInfo) -> Self {
-        Self {
-            height: value.height,
-            width: value.width,
-        }
-    }
-}
 
 /// A single page in a book
 #[derive(Clone, Debug)]
@@ -29,10 +12,12 @@ pub struct Page {
     pub filename: String,
     pub id: String,
     pub path: String,
-    pub dimension: Dimension,
 }
 
 impl Page {
+    /// Build a page from its path. This performs no image I/O — dimensions are
+    /// intentionally not read here so the initial scan only lists directories
+    /// instead of opening every image (a big win on spinning disks).
     pub fn new(seed: u64, path: &path::Path) -> anyhow::Result<Self> {
         if !path.is_file() {
             bail!("Not a file: {}", path.display());
@@ -42,12 +27,10 @@ impl Page {
             .and_then(|s| s.to_str().map(|s| s.to_string()))
             .with_context(|| format!("Invalid path: {}", path.display()))?;
         let path_str = path.to_string_lossy().to_string();
-        let dimension = Dimension::from(&imsz::imsz(path)?);
         Ok(Page {
-            filename,
             id: hash_string(seed, &path_str),
+            filename,
             path: path_str,
-            dimension,
         })
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,6 +2,6 @@ mod book;
 mod ids;
 mod scan;
 
-pub use book::{Book, Dimension, Page};
+pub use book::{Book, Page};
 pub use ids::{BookId, PageId, hash_string};
 pub use scan::{BookScan, scan_books, scan_pages};

--- a/templates/book.html
+++ b/templates/book.html
@@ -50,13 +50,7 @@
       <div class="pages" id="pages">
         {% for page in book.pages %}
         <figure class="pg" data-p="{{ loop.index }}">
-          <img
-            src="/data/{{ page.id }}"
-            width="{{ page.dimension.width }}"
-            height="{{ page.dimension.height }}"
-            alt="{{ page.filename }}"
-            loading="lazy"
-          />
+          <img src="/data/{{ page.id }}" alt="{{ page.filename }}" loading="lazy" />
         </figure>
         {% endfor %}
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,13 +66,7 @@
           {% for b in books %}
           <a class="card" href="/book/{{ b.id }}">
             <div class="cover">
-              <img
-                src="/data/{{ b.cover.id }}"
-                width="{{ b.cover.dimension.width }}"
-                height="{{ b.cover.dimension.height }}"
-                alt="{{ b.title }}"
-                loading="lazy"
-              />
+              <img src="/data/{{ b.cover.id }}" alt="{{ b.title }}" loading="lazy" />
               <span class="idx">{{ loop.index }}</span>
             </div>
             <div class="info">

--- a/vendor/assets/app.css
+++ b/vendor/assets/app.css
@@ -249,7 +249,9 @@ body[data-mode="paged"] .pg.is-current img { max-width: 100%; max-height: calc(1
 /* scroll mode: continuous vertical column */
 body[data-mode="scroll"] .pages { display: flex; flex-direction: column; align-items: center; gap: 16px; overflow-y: auto; padding: 22px 12px 60px; }
 body[data-mode="scroll"] .pg { display: block; width: 100%; max-width: 760px; }
-body[data-mode="scroll"] .pg img { width: 100%; height: auto; box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18); }
+/* aspect-ratio reserves space before load (we no longer ship intrinsic w/h);
+   the `auto` keyword lets the real image ratio take over once decoded. */
+body[data-mode="scroll"] .pg img { width: 100%; height: auto; aspect-ratio: auto 2 / 3; box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18); }
 body[data-mode="scroll"] .zone { display: none; }
 
 /* tap/click zones cover the full half so the whole left/right side flips */


### PR DESCRIPTION
## Summary

The initial scan called `imsz` on **every page** to read its dimensions — one file open (and a disk seek) per image. For a NAS on a spinning disk, this dominates the initial scan of a large library.

Dimensions were only used for `<img>` `width`/`height` (layout-shift hints), so this stops reading them at scan time: the scan now just lists directories and hashes paths, opening **no** image files.

- Removed the `Dimension` type and the `imsz` dependency.
- Templates drop the now-absent `width`/`height`.
- Reader scroll mode uses `aspect-ratio: auto 2 / 3` to reserve space before each image decodes (the `auto` keyword lets the real ratio take over once loaded). The cover grid already used `aspect-ratio: 3 / 4`, so it is unaffected.

## Benchmark

10,000 images (200 books × 50 pages), local SSD, warm cache, `comics list` (release build). Open counts captured with an `LD_PRELOAD` shim — hardware-independent.

| metric | before | after |
| --- | --- | --- |
| image file opens | 10,000 | **0** |
| total `open` syscalls | 10,014 | 14 |
| scan wall-clock | ~16.2 ms | ~6.5 ms (≈2.5×) |

On an HDD each eliminated open is a seek (~5–12 ms), so the real-world win is far larger than the SSD/warm-cache figures above (minutes → seconds for large libraries).

## Trade-off

Without intrinsic `width`/`height`, reader scroll mode can shift slightly as images decode; the `aspect-ratio` placeholder keeps this minimal, and the cover grid/paged reader are unaffected (CSS controls their boxes).

## Test plan
- `cargo fmt`, `cargo build`, `cargo nextest run` → 47/47 passing.
- Smoke test: `/` and `/book/{id}` return 200; cover/page `<img>` render without dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)