### PR TITLE
feat: serve generated thumbnails for covers and the reader rail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,10 +288,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -390,6 +408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +432,7 @@ dependencies = [
  "chrono",
  "clap",
  "http",
+ "image",
  "parking_lot",
  "rand",
  "rayon",
@@ -446,6 +471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -586,10 +620,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -659,6 +712,16 @@ dependencies = [
  "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -916,6 +979,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1131,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1149,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1202,6 +1313,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1368,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1513,6 +1649,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -2067,6 +2209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,3 +2558,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bcrypt = "0.19.1"
 chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 http = "1.4.1"
+image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 parking_lot = "0.12.1"
 rand = "0.10.0"
 rayon = "1.12.0"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 ## Features
 
 - **Simple Structure**: Comics looks only at the immediate subdirectories of your chosen folder. Each directory is treated as a book, and the files inside as the pages. No nested subfolders will be scanned. This simplicity ensures you have a clear structure for your comics.
-- **Manga-friendly Reader**: Read right-to-left page by page or as a continuous vertical scroll, switchable on the fly. Includes a progress bar, a thumbnail strip for jumping between pages, keyboard navigation, and a light/dark theme that follows your system and can be toggled manually.
+- **Manga-friendly Reader**: Read right-to-left page by page or as a continuous vertical scroll, switchable on the fly. Includes a progress bar, a thumbnail strip for jumping between pages, keyboard navigation, and a light/dark theme that follows your system and can be toggled manually. Covers and the thumbnail strip are served as small JPEG thumbnails generated on demand and cached on disk, so browsing stays light even on slow storage.
 - **Basic Authentication**: Safeguard your comics with a simple username-password protection. See [Commands](#commands) and [Environment Variables](#environment-variables) for setup.
 
 ## Environment Variables
@@ -30,6 +30,7 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 | `AUTH_PASSWORD_HASH` | Hashed password for basic authentication | _(none)_ |
 | `BIND` | Bind host & port | `127.0.0.1:3000` |
 | `DATA_DIR` | Data directory | `./data` |
+| `CACHE_DIR` | Directory for cached thumbnails | `comics-thumbs` under the system temp dir |
 | `DEBUG` | Enable debug mode | _(off)_ |
 | `LOG_FORMAT` | Log format (`full`, `compact`, `pretty`, `json`) | `full` |
 | `NO_COLOR` | Disable color output ([no-color.org](https://no-color.org/)) | _(off)_ |

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -93,6 +93,8 @@ mod tests {
             data_dir: PathBuf::from("/tmp"),
             scan: Arc::new(RwLock::new(None)),
             seed: 0,
+            cache_dir: PathBuf::from("/tmp"),
+            thumb_sem: Arc::new(tokio::sync::Semaphore::new(1)),
         })
     }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -4,6 +4,7 @@ mod index;
 mod page;
 mod rescan;
 mod shuffle;
+mod thumb;
 
 pub use book::show_book_route;
 pub use health::{Healthz, healthz_route};
@@ -11,3 +12,4 @@ pub use index::index_route;
 pub use page::show_page_route;
 pub use rescan::rescan_books_route;
 pub use shuffle::{shuffle_book_route, shuffle_route};
+pub use thumb::show_thumb_route;

--- a/src/handlers/page.rs
+++ b/src/handlers/page.rs
@@ -10,7 +10,7 @@ use tracing::{debug, error};
 use crate::state::AppState;
 
 /// Infer Content-Type from file extension
-fn content_type_from_path(path: &str) -> &'static str {
+pub(crate) fn content_type_from_path(path: &str) -> &'static str {
     match path
         .rsplit('.')
         .next()

--- a/src/handlers/thumb.rs
+++ b/src/handlers/thumb.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Response},
+};
+use http::{StatusCode, header};
+use image::ImageReader;
+use tokio::fs;
+use tracing::{debug, error};
+
+use super::page::content_type_from_path;
+use crate::state::AppState;
+
+/// JPEG quality used for generated thumbnails.
+const THUMB_QUALITY: u8 = 72;
+
+/// Map a size keyword to a maximum edge length in pixels.
+fn size_px(name: &str) -> Option<u32> {
+    match name {
+        "sm" => Some(120), // reader thumbnail rail
+        "md" => Some(400), // library covers
+        _ => None,
+    }
+}
+
+/// Decode `path`, shrink it to fit within `max`×`max`, and JPEG-encode it.
+fn generate(path: &str, max: u32) -> anyhow::Result<Vec<u8>> {
+    let img = ImageReader::open(path)?.with_guessed_format()?.decode()?;
+    let thumb = img.thumbnail(max, max).to_rgb8();
+    let mut buf = Vec::new();
+    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, THUMB_QUALITY)
+        .encode_image(&thumb)?;
+    Ok(buf)
+}
+
+fn jpeg_response(bytes: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "image/jpeg"),
+            (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
+/// Serve a cached or freshly generated thumbnail for a page.
+///
+/// `GET /thumb/{size}/{id}` where size is `sm` or `md`. Thumbnails are written
+/// to the cache dir on first request and read back on subsequent ones, so the
+/// full-resolution source is opened at most once per (size, page).
+pub async fn show_thumb_route(
+    State(state): State<Arc<AppState>>,
+    Path((size, id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    let max = match size_px(&size) {
+        Some(m) => m,
+        None => return (StatusCode::NOT_FOUND, Vec::new()).into_response(),
+    };
+
+    // Resolve the source path, releasing the lock before any I/O.
+    let src = {
+        let locked = state.scan.read();
+        let scan = match locked.as_ref() {
+            None => return (StatusCode::SERVICE_UNAVAILABLE, Vec::new()).into_response(),
+            Some(scan) => scan,
+        };
+        match scan.pages_map.get(&id) {
+            None => return (StatusCode::NOT_FOUND, Vec::new()).into_response(),
+            Some(page) => page.path.clone(),
+        }
+    };
+
+    // Serve from cache when present.
+    let cache_path = state.cache_dir.join(&size).join(format!("{id}.jpg"));
+    if let Ok(bytes) = fs::read(&cache_path).await {
+        return jpeg_response(bytes);
+    }
+
+    // Generate, bounding concurrency so opening a book does not spawn a decode
+    // storm. The permit is held across the blocking work.
+    let _permit = state.thumb_sem.acquire().await;
+    let src_for_gen = src.clone();
+    let bytes = match tokio::task::spawn_blocking(move || generate(&src_for_gen, max)).await {
+        Ok(Ok(bytes)) => bytes,
+        Ok(Err(err)) => {
+            // Undecodable source: fall back to the original so the UI still shows something.
+            debug!(%err, path = %src, "thumbnail generation failed; serving original");
+            return serve_original(&src).await;
+        }
+        Err(err) => {
+            error!(%err, "thumbnail task panicked");
+            return (StatusCode::INTERNAL_SERVER_ERROR, Vec::new()).into_response();
+        }
+    };
+
+    // Best-effort cache write; serving succeeds even if the cache dir is not writable.
+    if let Some(parent) = cache_path.parent() {
+        let _ = fs::create_dir_all(parent).await;
+    }
+    if let Err(err) = fs::write(&cache_path, &bytes).await {
+        debug!(%err, path = %cache_path.display(), "failed to write thumbnail cache");
+    }
+    jpeg_response(bytes)
+}
+
+/// Fallback: stream the original image when a thumbnail cannot be produced.
+async fn serve_original(path: &str) -> Response {
+    match fs::read(path).await {
+        Ok(content) => (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, content_type_from_path(path)),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
+            content,
+        )
+            .into_response(),
+        Err(_) => (StatusCode::NOT_FOUND, Vec::new()).into_response(),
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -53,6 +53,8 @@ mod tests {
             data_dir: PathBuf::from("/tmp"),
             scan: Arc::new(RwLock::new(scan)),
             seed: 0,
+            cache_dir: PathBuf::from("/tmp"),
+            thumb_sem: Arc::new(tokio::sync::Semaphore::new(1)),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use auth::{AuthConfig, auth_middleware_fn};
 pub use error::{AppError, AppResult};
 pub use handlers::{
     Healthz, healthz_route, index_route, rescan_books_route, show_book_route, show_page_route,
-    shuffle_book_route, shuffle_route,
+    show_thumb_route, shuffle_book_route, shuffle_route,
 };
 pub use models::{Book, BookScan, Page, scan_books};
 pub use state::AppState;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,10 @@ use parking_lot::RwLock;
 use tokio::{
     net::TcpListener,
     signal,
-    sync::oneshot::{self, Sender},
+    sync::{
+        Semaphore,
+        oneshot::{self, Sender},
+    },
 };
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::{Level, debug, error, info, warn};
@@ -29,7 +32,8 @@ use tracing_subscriber::{
 use comics::{
     APP_CSS, APP_JS, APPLE_TOUCH_ICON_PNG, AppState, AuthConfig, BCRYPT_COST, FAVICON_PNG,
     FAVICON_SVG, VERSION, auth_middleware_fn, healthz_route, index_route, rescan_books_route,
-    scan_books, show_book_route, show_page_route, shuffle_book_route, shuffle_route,
+    scan_books, show_book_route, show_page_route, show_thumb_route, shuffle_book_route,
+    shuffle_route,
 };
 
 // Assets are fingerprinted in the URL (`?v=<hash>`), so they can be cached
@@ -71,6 +75,9 @@ struct Opts {
     /// Data directory
     #[arg(long, env = "DATA_DIR", default_value = "./data")]
     data_dir: PathBuf,
+    /// Directory for cached thumbnails (defaults to a "comics-thumbs" dir under the system temp dir)
+    #[arg(long, env = "CACHE_DIR")]
+    cache_dir: Option<PathBuf>,
     /// Log format
     #[arg(long, env = "LOG_FORMAT", default_value = "full")]
     log_format: LogFormat,
@@ -146,6 +153,13 @@ fn init_route(opts: &Opts) -> anyhow::Result<(Router, Arc<AppState>)> {
         data_dir: data_dir.clone(),
         scan: Arc::new(RwLock::new(None)),
         seed,
+        cache_dir: opts
+            .cache_dir
+            .clone()
+            .unwrap_or_else(|| std::env::temp_dir().join("comics-thumbs")),
+        thumb_sem: Arc::new(Semaphore::new(
+            thread::available_parallelism().map_or(4, |n| n.get()),
+        )),
     });
 
     let router = Router::new()
@@ -161,6 +175,7 @@ fn init_route(opts: &Opts) -> anyhow::Result<(Router, Arc<AppState>)> {
         // to prevent timing attack, bcrypt is too slow
         // protected by randomly-generated string as page ID instead
         .route("/data/{id}", get(show_page_route))
+        .route("/thumb/{size}/{id}", get(show_thumb_route))
         .route("/healthz", get(healthz_route))
         .route("/assets/app.css", get(|| async { (CSS_HEADERS, APP_CSS) }))
         .route("/assets/app.js", get(|| async { (JS_HEADERS, APP_JS) }))
@@ -417,8 +432,8 @@ mod tests {
 
         // Discover the page id the scan assigned (cover of the only book).
         let html = server.get("/").await.text();
-        let marker = "/data/";
-        let start = html.find(marker).expect("a page link") + marker.len();
+        let marker = "/thumb/md/";
+        let start = html.find(marker).expect("a cover link") + marker.len();
         let id: String = html[start..].chars().take_while(|&c| c != '"').collect();
         assert!(!id.is_empty());
 
@@ -426,6 +441,33 @@ mod tests {
         assert_eq!(200, server.get(&format!("/data/{id}")).await.status_code());
         fs::remove_file(&page).unwrap();
         assert_eq!(404, server.get(&format!("/data/{id}")).await.status_code());
+    }
+
+    #[tokio::test]
+    async fn thumbnail_serves_jpeg() {
+        let server = build_server().await;
+
+        // The cover link on the index uses the medium thumbnail endpoint.
+        let html = server.get("/").await.text();
+        let marker = "/thumb/md/";
+        let start = html.find(marker).expect("a cover thumbnail") + marker.len();
+        let id: String = html[start..].chars().take_while(|&c| c != '"').collect();
+
+        for size in ["md", "sm"] {
+            let res = server.get(&format!("/thumb/{size}/{id}")).await;
+            assert_eq!(200, res.status_code(), "size {size}");
+            assert!(
+                res.as_bytes().starts_with(b"\xFF\xD8\xFF"),
+                "JPEG magic for {size}"
+            );
+        }
+
+        // Unknown size and unknown id both 404.
+        assert_eq!(
+            404,
+            server.get(&format!("/thumb/xl/{id}")).await.status_code()
+        );
+        assert_eq!(404, server.get("/thumb/md/deadbeef").await.status_code());
     }
 
     #[tokio::test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use parking_lot::RwLock;
+use tokio::sync::Semaphore;
 
 use crate::auth::AuthConfig;
 use crate::models::BookScan;
@@ -12,4 +13,8 @@ pub struct AppState {
     pub data_dir: PathBuf,
     pub scan: Arc<RwLock<Option<BookScan>>>,
     pub seed: u64,
+    /// Directory where generated thumbnails are cached.
+    pub cache_dir: PathBuf,
+    /// Bounds concurrent thumbnail generation (CPU-bound decode + resize).
+    pub thumb_sem: Arc<Semaphore>,
 }

--- a/templates/book.html
+++ b/templates/book.html
@@ -62,7 +62,7 @@
       <div class="thumbs" id="thumbs">
         {% for page in book.pages %}
         <button type="button" data-p="{{ loop.index }}" title="第{{ loop.index }}頁">
-          <img src="/data/{{ page.id }}" alt="" loading="lazy" />
+          <img src="/thumb/sm/{{ page.id }}" alt="" loading="lazy" />
         </button>
         {% endfor %}
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,7 +66,7 @@
           {% for b in books %}
           <a class="card" href="/book/{{ b.id }}">
             <div class="cover">
-              <img src="/data/{{ b.cover.id }}" alt="{{ b.title }}" loading="lazy" />
+              <img src="/thumb/md/{{ b.cover.id }}" alt="{{ b.title }}" loading="lazy" />
               <span class="idx">{{ loop.index }}</span>
             </div>
             <div class="info">


### PR DESCRIPTION
## Summary

The library covers and the reader's thumbnail strip previously loaded **full-resolution** images scaled down by the browser — wasting bandwidth, and (on a NAS) disk reads. This adds a thumbnail endpoint.

`GET /thumb/{size}/{id}` decodes the source image once, shrinks it, JPEG-encodes it, and **caches it to disk**; subsequent requests serve the small cached file. Generation is **lazy** (only pages actually viewed), bounded by a semaphore so opening a book doesn't spawn a decode storm, and falls back to the original image if a source can't be decoded.

- **Two sizes:** `sm` (120 px, reader rail) and `md` (400 px, covers).
- **Pure-Rust `image` crate** (jpeg/png/gif/webp decode, jpeg encode) — no `libwebp`/C dependency, so the arm64 Docker cross-compile is unaffected.
- **New `--cache-dir` / `CACHE_DIR`** (defaults to a `comics-thumbs` dir under the system temp dir).
- Templates point the rail at `/thumb/sm` and covers at `/thumb/md`; full-screen reading still uses the original `/data` image.

## Benchmark

5 books, a 20-page book, ~444 KB/page source images. Bytes are summed `Content-Length` via `curl`.

| scenario | `/data` (original) | `/thumb` | saving |
| --- | --- | --- | --- |
| library (5 covers) | 2.1 MB | 94.5 KB | **96% (23×)** |
| open a book (20 rail thumbs) | 8.5 MB | 57.9 KB | **99% (150×)** |

| | cold generate | cached hit |
| --- | --- | --- |
| `md` (400 px) | ~125 ms | ~0.27 ms |
| `sm` (120 px) | ~117 ms | ~0.24 ms |

Generation is a one-time cost per (size, page); cached serves are ~0.25 ms.

## Test plan
- `cargo fmt`, `cargo clippy --all-targets`, `cargo nextest run` → 48/48 passing.
- New test `thumbnail_serves_jpeg`: `/thumb/{sm,md}/{id}` return JPEG (200); unknown size and unknown id return 404.

## Notes / possible follow-ups
- Cache is keyed by page id; `/rescan` does not purge it (content is effectively immutable). Could add cache purging on rescan if needed.
- An in-memory LRU and/or cached WebP remain optional future steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)