### PR TITLE
test: cover thumbnail/page/book branches and lift coverage

### DIFF
--- a/src/handlers/page.rs
+++ b/src/handlers/page.rs
@@ -66,3 +66,26 @@ pub async fn show_page_route(
     )
         .into_response()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::content_type_from_path;
+
+    #[test]
+    fn content_type_covers_known_and_unknown_extensions() {
+        assert_eq!(content_type_from_path("a/b.jpg"), "image/jpeg");
+        assert_eq!(content_type_from_path("a/b.JPEG"), "image/jpeg");
+        assert_eq!(content_type_from_path("a/b.png"), "image/png");
+        assert_eq!(content_type_from_path("a/b.gif"), "image/gif");
+        assert_eq!(content_type_from_path("a/b.webp"), "image/webp");
+        assert_eq!(content_type_from_path("a/b.avif"), "image/avif");
+        assert_eq!(
+            content_type_from_path("a/b.txt"),
+            "application/octet-stream"
+        );
+        assert_eq!(
+            content_type_from_path("noextension"),
+            "application/octet-stream"
+        );
+    }
+}

--- a/src/handlers/thumb.rs
+++ b/src/handlers/thumb.rs
@@ -121,3 +121,53 @@ async fn serve_original(path: &str) -> Response {
         Err(_) => (StatusCode::NOT_FOUND, Vec::new()).into_response(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::AuthConfig;
+    use axum::extract::{Path as AxumPath, State};
+    use parking_lot::RwLock;
+    use std::path::PathBuf;
+    use tokio::sync::Semaphore;
+
+    fn state_without_scan() -> Arc<AppState> {
+        Arc::new(AppState {
+            auth_config: AuthConfig::None,
+            data_dir: PathBuf::from("/tmp"),
+            scan: Arc::new(RwLock::new(None)),
+            seed: 0,
+            cache_dir: PathBuf::from("/tmp"),
+            thumb_sem: Arc::new(Semaphore::new(1)),
+        })
+    }
+
+    #[test]
+    fn size_px_allowlist() {
+        assert_eq!(size_px("sm"), Some(120));
+        assert_eq!(size_px("md"), Some(400));
+        assert_eq!(size_px("lg"), None);
+    }
+
+    #[tokio::test]
+    async fn unknown_size_is_not_found() {
+        let res = show_thumb_route(
+            State(state_without_scan()),
+            AxumPath(("lg".to_string(), "x".to_string())),
+        )
+        .await
+        .into_response();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn unavailable_before_first_scan() {
+        let res = show_thumb_route(
+            State(state_without_scan()),
+            AxumPath(("md".to_string(), "x".to_string())),
+        )
+        .await
+        .into_response();
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,12 +462,48 @@ mod tests {
             );
         }
 
+        // The second request for the same thumbnail is served from the disk cache.
+        let cached = server.get(&format!("/thumb/md/{id}")).await;
+        assert_eq!(200, cached.status_code());
+        assert!(cached.as_bytes().starts_with(b"\xFF\xD8\xFF"));
+
         // Unknown size and unknown id both 404.
         assert_eq!(
             404,
             server.get(&format!("/thumb/xl/{id}")).await.status_code()
         );
         assert_eq!(404, server.get("/thumb/md/deadbeef").await.status_code());
+    }
+
+    #[tokio::test]
+    async fn thumbnail_falls_back_to_original_when_undecodable() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        // A "page" that is not a valid image.
+        let dir = tempdir().unwrap();
+        let book = dir.path().join("Bogus Book");
+        fs::create_dir(&book).unwrap();
+        let page = book.join("01.jpg");
+        fs::write(&page, b"this is not an image").unwrap();
+
+        let server = build_server_at(dir.path().to_str().unwrap()).await;
+        let html = server.get("/").await.text();
+        let marker = "/thumb/md/";
+        let start = html.find(marker).expect("a cover link") + marker.len();
+        let id: String = html[start..].chars().take_while(|&c| c != '"').collect();
+
+        // Undecodable source falls back to the original bytes.
+        let res = server.get(&format!("/thumb/sm/{id}")).await;
+        assert_eq!(200, res.status_code());
+        assert_eq!(res.as_bytes(), &b"this is not an image"[..]);
+
+        // Once the original is gone, the fallback 404s.
+        fs::remove_file(&page).unwrap();
+        assert_eq!(
+            404,
+            server.get(&format!("/thumb/sm/{id}")).await.status_code()
+        );
     }
 
     #[tokio::test]

--- a/src/models/book.rs
+++ b/src/models/book.rs
@@ -66,3 +66,56 @@ impl Book {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+    use tracing::trace_span;
+
+    #[test]
+    fn page_new_rejects_a_directory() {
+        let dir = tempdir().unwrap();
+        assert!(Page::new(0, dir.path()).is_err());
+    }
+
+    #[test]
+    fn page_new_builds_from_a_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("01.jpg");
+        fs::write(&path, b"data").unwrap();
+        let page = Page::new(7, &path).unwrap();
+        assert_eq!(page.filename, "01.jpg");
+        assert!(!page.id.is_empty());
+    }
+
+    #[test]
+    fn book_new_rejects_a_non_directory() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("loose.txt");
+        fs::write(&file, b"x").unwrap();
+        assert!(Book::new(&trace_span!("test"), 0, &file).is_err());
+    }
+
+    #[test]
+    fn book_new_rejects_an_empty_directory() {
+        let dir = tempdir().unwrap();
+        let empty = dir.path().join("empty");
+        fs::create_dir(&empty).unwrap();
+        assert!(Book::new(&trace_span!("test"), 0, &empty).is_err());
+    }
+
+    #[test]
+    fn book_new_builds_with_sorted_pages() {
+        let dir = tempdir().unwrap();
+        let book = dir.path().join("My Book");
+        fs::create_dir(&book).unwrap();
+        fs::write(book.join("02.jpg"), b"x").unwrap();
+        fs::write(book.join("01.jpg"), b"x").unwrap();
+        let b = Book::new(&trace_span!("test"), 1, &book).unwrap();
+        assert_eq!(b.title, "My Book");
+        assert_eq!(b.pages.len(), 2);
+        assert_eq!(b.cover.filename, "01.jpg");
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #322. The thumbnail endpoint merged with mostly untested error/fallback paths (Codecov patch/project went red). This adds tests and, while at it, lifts overall coverage a tier.

**Coverage: ~87.4% → ~91.3% region (line ~88.7% → ~92.3%), measured locally with `cargo llvm-cov nextest` (same as CI).**

| file | before | after |
| --- | --- | --- |
| `handlers/thumb.rs` | 38% | 77% |
| `handlers/page.rs` | 72% | 93% |
| `models/book.rs` | 72% | 94% |

### What was added
- **thumb.rs** — unit tests for an unknown size keyword (404) and a request before the first scan (503); bin tests for the on-disk cache hit (second request) and the decode-failure fallback (serves the original bytes, then 404 once the file is removed).
- **page.rs** — unit test for `content_type_from_path` across jpg/jpeg/png/gif/webp/avif/unknown.
- **models/book.rs** — unit tests for `Page::new` and `Book::new` happy and error paths (non-file, non-dir, empty dir, sorted pages/cover).

No production code changed — tests only.

## Test plan
- `cargo fmt`, `cargo clippy --all-targets --all-features` (clean), `cargo nextest run` → 58/58 passing (was 48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)