### PR TITLE
feat: replace basic auth with web form login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
 dependencies = [
  "base64",
  "blowfish",
- "getrandom",
+ "getrandom 0.4.2",
  "subtle",
  "zeroize",
 ]
@@ -260,6 +260,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "blowfish"
@@ -340,8 +349,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -363,7 +372,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.1",
  "inout",
 ]
 
@@ -431,10 +440,11 @@ dependencies = [
  "bcrypt",
  "chrono",
  "clap",
+ "cookie",
  "http",
  "image",
  "parking_lot",
- "rand",
+ "rand 0.10.1",
  "rayon",
  "rpassword",
  "serde",
@@ -454,6 +464,12 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "base64",
+ "hmac",
+ "percent-encoding",
+ "rand 0.8.6",
+ "sha2",
+ "subtle",
  "time",
  "version_check",
 ]
@@ -463,6 +479,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -509,6 +534,16 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
@@ -530,6 +565,17 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -701,6 +747,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,7 +776,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -750,6 +817,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1341,6 +1417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,13 +1483,43 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1512,7 +1627,7 @@ dependencies = [
  "futures-util",
  "http",
  "mime",
- "rand",
+ "rand 0.10.1",
  "thiserror",
 ]
 
@@ -1623,6 +1738,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1766,7 +1892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2491,6 +2617,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,6 @@ dependencies = [
  "askama",
  "axum",
  "axum-test",
- "base64",
  "bcrypt",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT"
 anyhow = "1.0.102"
 askama = "0.16.0"
 axum = "0.8.9"
-base64 = "0.22.0"
 bcrypt = "0.19.1"
 chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.22.0"
 bcrypt = "0.19.1"
 chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["derive", "env"] }
+cookie = { version = "0.18.1", default-features = false, features = ["signed", "percent-encode"] }
 http = "1.4.1"
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 parking_lot = "0.12.1"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 
 - **Simple Structure**: Comics looks only at the immediate subdirectories of your chosen folder. Each directory is treated as a book, and the files inside as the pages. No nested subfolders will be scanned. This simplicity ensures you have a clear structure for your comics.
 - **Manga-friendly Reader**: Read right-to-left page by page or as a continuous vertical scroll, switchable on the fly. Includes a progress bar, a thumbnail strip for jumping between pages, keyboard navigation, and a light/dark theme that follows your system and can be toggled manually. Covers and the thumbnail strip are served as small JPEG thumbnails generated on demand and cached on disk, so browsing stays light even on slow storage.
-- **Web Login**: Safeguard your comics with a username-password login form backed by a signed session cookie (valid for 7 days). Credentials are verified once at login instead of on every request. See [Commands](#commands) and [Environment Variables](#environment-variables) for setup.
+- **Web Login**: Safeguard your comics with a username-password login form backed by a signed session cookie (valid for 7 days). Credentials are verified once at login instead of on every request, and every page — including the images and thumbnails themselves — is served only to logged-in users. See [Commands](#commands) and [Environment Variables](#environment-variables) for setup.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 
 - **Simple Structure**: Comics looks only at the immediate subdirectories of your chosen folder. Each directory is treated as a book, and the files inside as the pages. No nested subfolders will be scanned. This simplicity ensures you have a clear structure for your comics.
 - **Manga-friendly Reader**: Read right-to-left page by page or as a continuous vertical scroll, switchable on the fly. Includes a progress bar, a thumbnail strip for jumping between pages, keyboard navigation, and a light/dark theme that follows your system and can be toggled manually. Covers and the thumbnail strip are served as small JPEG thumbnails generated on demand and cached on disk, so browsing stays light even on slow storage.
-- **Basic Authentication**: Safeguard your comics with a simple username-password protection. See [Commands](#commands) and [Environment Variables](#environment-variables) for setup.
+- **Web Login**: Safeguard your comics with a username-password login form backed by a signed session cookie (valid for 7 days). Credentials are verified once at login instead of on every request. See [Commands](#commands) and [Environment Variables](#environment-variables) for setup.
 
 ## Environment Variables
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `AUTH_USERNAME` | Username for basic authentication | _(none)_ |
-| `AUTH_PASSWORD_HASH` | Hashed password for basic authentication | _(none)_ |
+| `AUTH_USERNAME` | Username for the login form | _(none)_ |
+| `AUTH_PASSWORD_HASH` | Hashed password for the login form | _(none)_ |
 | `BIND` | Bind host & port | `127.0.0.1:3000` |
 | `DATA_DIR` | Data directory | `./data` |
 | `CACHE_DIR` | Directory for cached thumbnails | `comics-thumbs` under the system temp dir |
@@ -79,7 +79,7 @@ Now, open your web browser and head to http://localhost:3000/ to view your comic
 
 ### `hash-password`
 
-Generate a bcrypt-hashed password for basic authentication:
+Generate a bcrypt-hashed password for the login form:
 
 ```bash
 $ comics hash-password

--- a/docs/superpowers/specs/2026-06-14-web-login-auth-design.md
+++ b/docs/superpowers/specs/2026-06-14-web-login-auth-design.md
@@ -1,0 +1,79 @@
+# Web form login (signed cookie) — design
+
+Replace HTTP Basic Auth for the GUI with a form-based login backed by a
+stateless, signed session cookie. Mirrors Syncthing's v1.26 change, motivated by
+the same two problems: bcrypt runs on *every* request under Basic Auth (painful
+on low-powered hardware), and the browser's native Basic Auth dialog plays badly
+with password managers and has no logout.
+
+## Decisions
+
+- **Complete replacement**: Basic Auth is removed entirely (no compatibility mode).
+- **Stateless signed cookie**: no server-side session store. A random signing
+  key is generated at startup, so a restart invalidates all sessions. No
+  individual revocation.
+- **Fixed 7-day expiry**, no "remember me" checkbox, no configurable TTL.
+
+## Architecture
+
+Credential configuration is unchanged: `AuthConfig::{None, Some{username,
+password_hash}}`, supplied via `--auth-username` / `--auth-password-hash` env/CLI
+and the `hash-password` subcommand. Only the transport of credentials and the
+"already logged in" check change.
+
+- **Login**: `GET /login` renders a form; `POST /login` verifies credentials
+  with bcrypt **once** and issues a signed cookie.
+- **Subsequent requests**: middleware verifies the cookie signature and expiry
+  (cheap) instead of running bcrypt per request.
+- **Logout**: `POST /logout` clears the cookie.
+
+## Dependencies
+
+Add `axum-extra` with the `cookie-signed` feature. Its `SignedCookieJar` handles
+HMAC signing/verification of the cookie, avoiding hand-rolled cryptography. At
+startup, generate a random signing `Key` (via `rand`) and store it in
+`AppState`; implement `FromRef<AppState>` for `Key` so the jar extractor works.
+
+## Cookie
+
+- Name `comics_session`; value = expiry unix timestamp (login time + 7 days).
+- Attributes: `HttpOnly`, `SameSite=Lax`, `Path=/`, `Max-Age=604800`.
+- The signature (via `SignedCookieJar`) makes the value unforgeable; the
+  middleware additionally checks `now < expiry` so expiry is enforced
+  server-side, not only by the browser.
+
+## Routes & middleware
+
+| Route | Behaviour |
+|-------|-----------|
+| `GET /login` | Public. If already authenticated, 303 to `/`. |
+| `POST /login` | Form `username`/`password`; bcrypt verify. Success → set cookie + 303 to `next` (default `/`). Failure → re-render form with an error. |
+| `POST /logout` | Remove cookie, 303 to `/login`. |
+| Protected (`/`, `/book`, `/shuffle`, `/rescan`) | Middleware checks the cookie. Unauthenticated GET → 303 to `/login?next=<path>`; unauthenticated POST → 401. `AuthConfig::None` → fully public. |
+| `/data`, `/thumb`, `/healthz`, assets | Public (unchanged). |
+
+The Basic parsing in `authenticate()` is removed and replaced with cookie
+verification. The `AuthState` enum is simplified (no `Request` /
+`WWW-Authenticate` variant).
+
+## UI
+
+- New `templates/login.html`, reusing the existing layout (`layout`/`aside`/
+  `lbtn` classes) and the pre-paint theme script.
+- Add a **Logout** form button to the control rows in `index.html` and
+  `book.html`, shown only when auth is enabled (template gets an `auth_enabled`
+  flag).
+
+## Testing
+
+- Rewrite the existing `auth_*` tests (no more `WWW-Authenticate` / Basic base64).
+- Add: login success sets cookie; wrong password re-renders; unauthenticated GET
+  on a protected route → 303 to `/login`; logout clears the cookie;
+  expired/tampered cookie treated as unauthenticated; `AuthConfig::None` stays
+  fully public.
+- Update the unit tests in `middleware.rs` to use cookies.
+
+## Out of scope (YAGNI)
+
+No Basic Auth compatibility, no "remember me" checkbox, no configurable TTL, no
+session revocation.

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -1,95 +1,124 @@
 use std::sync::Arc;
 
-use anyhow::bail;
 use axum::{
     extract::{Request, State},
     middleware::Next,
-    response::IntoResponse,
+    response::{IntoResponse, Redirect},
 };
-use base64::{Engine as _, engine::GeneralPurpose};
-use http::{StatusCode, header};
-use tracing::error;
+use chrono::Utc;
+use cookie::{Cookie, CookieJar, SameSite, time::Duration};
+use http::{Method, StatusCode, header};
 
 use super::config::AuthConfig;
 use crate::state::AppState;
 
-const BASE64_ENGINE: GeneralPurpose = base64::engine::general_purpose::STANDARD;
+/// Name of the signed session cookie.
+pub const SESSION_COOKIE: &str = "comics_session";
+/// How long a session stays valid after login.
+const SESSION_TTL_DAYS: i64 = 7;
 
-type SingleHeader = [(header::HeaderName, &'static str); 1];
-const WWW_AUTHENTICATE_HEADER: SingleHeader = [(header::WWW_AUTHENTICATE, "Basic realm=comics")];
-
-/// Authentication state after checking credentials
+/// Authentication state after checking the request.
 pub enum AuthState {
+    /// No credentials are configured; everything is public.
     Public,
-    Request,
-    Success,
-    Failed,
+    /// A valid, unexpired session cookie was presented.
+    Authenticated,
+    /// No valid session cookie was presented.
+    Unauthenticated,
 }
 
-/// Authenticate a request against the configured credentials
-pub fn authenticate(state: &Arc<AppState>, request: &Request) -> anyhow::Result<AuthState> {
-    let (expected_username, expected_password) = match &state.auth_config {
-        AuthConfig::None => return Ok(AuthState::Public),
-        AuthConfig::Some {
-            username,
-            password_hash,
-        } => (username, password_hash),
-    };
-    let header_value = match request.headers().get(header::AUTHORIZATION) {
-        None => return Ok(AuthState::Request),
-        Some(v) => v,
-    };
-    let header_str = header_value.to_str()?;
-    let mut parts = header_str.splitn(2, ' ');
-    let digest = match (parts.next(), parts.next()) {
-        (Some(scheme), Some(digest)) if scheme.eq_ignore_ascii_case("basic") => digest,
-        _ => return Ok(AuthState::Failed),
-    };
-    let decoded = BASE64_ENGINE.decode(digest)?;
-    let decoded_str = String::from_utf8(decoded)?;
-    let password = match decoded_str.split_once(':') {
-        Some((u, p)) if u == expected_username => p,
-        _ => return Ok(AuthState::Failed),
-    };
-    match bcrypt::verify(password, expected_password) {
-        Ok(true) => Ok(AuthState::Success),
-        Ok(false) => Ok(AuthState::Failed),
-        Err(err) => {
-            error!(?err, "failed to verify password");
-            bail!("Bcrypt error: {err}")
+/// Build a fresh, signed-cookie-ready session cookie whose value is the unix
+/// timestamp at which it expires. The signature (added by the caller's
+/// [`cookie::SignedJar`]) makes the value unforgeable; the timestamp lets the
+/// server enforce expiry independently of the browser.
+pub fn build_session_cookie() -> Cookie<'static> {
+    let expires_at = Utc::now().timestamp() + SESSION_TTL_DAYS * 24 * 60 * 60;
+    Cookie::build((SESSION_COOKIE, expires_at.to_string()))
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .path("/")
+        .max_age(Duration::days(SESSION_TTL_DAYS))
+        .build()
+}
+
+/// Parse the request's `Cookie` header into a jar.
+fn jar_from_request(request: &Request) -> CookieJar {
+    let mut jar = CookieJar::new();
+    for value in request.headers().get_all(header::COOKIE) {
+        let Ok(raw) = value.to_str() else { continue };
+        for cookie in Cookie::split_parse_encoded(raw.to_owned()).flatten() {
+            jar.add_original(cookie.into_owned());
         }
+    }
+    jar
+}
+
+/// Authenticate a request against the configured credentials.
+pub fn authenticate(state: &Arc<AppState>, request: &Request) -> AuthState {
+    if matches!(state.auth_config, AuthConfig::None) {
+        return AuthState::Public;
+    }
+    let jar = jar_from_request(request);
+    let Some(cookie) = jar.signed(&state.key).get(SESSION_COOKIE) else {
+        return AuthState::Unauthenticated;
+    };
+    match cookie.value().parse::<i64>() {
+        Ok(expires_at) if Utc::now().timestamp() < expires_at => AuthState::Authenticated,
+        _ => AuthState::Unauthenticated,
     }
 }
 
-/// Axum middleware function for authentication
+/// Axum middleware function for authentication.
 pub async fn auth_middleware_fn(
     State(state): State<Arc<AppState>>,
     request: Request,
     next: Next,
 ) -> impl IntoResponse {
     match authenticate(&state, &request) {
-        Ok(AuthState::Public | AuthState::Success) => next.run(request).await,
-        Ok(AuthState::Failed) => StatusCode::UNAUTHORIZED.into_response(),
-        Ok(AuthState::Request) => {
-            (StatusCode::UNAUTHORIZED, WWW_AUTHENTICATE_HEADER, "").into_response()
-        }
-        Err(err) => {
-            error!(%err, "failed to authenticate");
-            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        AuthState::Public | AuthState::Authenticated => next.run(request).await,
+        AuthState::Unauthenticated => {
+            // Bounce browsers (GET navigations) to the login form, preserving
+            // where they were headed; reject API-style writes with 401.
+            if request.method() == Method::GET {
+                let next_path = request.uri().path_and_query().map_or_else(
+                    || request.uri().path().to_owned(),
+                    |pq| pq.as_str().to_owned(),
+                );
+                let target = format!("/login?next={}", urlencode(&next_path));
+                Redirect::to(&target).into_response()
+            } else {
+                StatusCode::UNAUTHORIZED.into_response()
+            }
         }
     }
+}
+
+/// Minimal percent-encoding for the `next` query parameter.
+fn urlencode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::http::Request as HttpRequest;
+    use cookie::Key;
     use parking_lot::RwLock;
     use std::path::PathBuf;
 
-    fn create_state(auth_config: AuthConfig) -> Arc<AppState> {
+    fn create_state(auth_config: AuthConfig, key: Key) -> Arc<AppState> {
         Arc::new(AppState {
             auth_config,
+            key,
             data_dir: PathBuf::from("/tmp"),
             scan: Arc::new(RwLock::new(None)),
             seed: 0,
@@ -98,96 +127,98 @@ mod tests {
         })
     }
 
-    fn create_request_with_auth(auth_header: Option<&str>) -> Request {
+    fn some_auth() -> AuthConfig {
+        AuthConfig::Some {
+            username: "user".to_string(),
+            password_hash: bcrypt::hash("pass", 4).unwrap(),
+        }
+    }
+
+    /// Sign `cookie` with `key` and render it as a browser `Cookie` header value.
+    fn signed_header(key: &Key, cookie: Cookie<'static>) -> String {
+        let mut jar = CookieJar::new();
+        jar.signed_mut(key).add(cookie);
+        jar.get(SESSION_COOKIE)
+            .unwrap()
+            .clone()
+            .stripped()
+            .encoded()
+            .to_string()
+    }
+
+    fn request_with_cookie(cookie_header: Option<&str>) -> Request {
         let mut builder = HttpRequest::builder().uri("/").method("GET");
-        if let Some(auth) = auth_header {
-            builder = builder.header(header::AUTHORIZATION, auth);
+        if let Some(value) = cookie_header {
+            builder = builder.header(header::COOKIE, value);
         }
         builder.body(axum::body::Body::empty()).unwrap()
     }
 
     #[test]
     fn authenticate_public_when_no_auth_config() {
-        let state = create_state(AuthConfig::None);
-        let request = create_request_with_auth(None);
-        let result = authenticate(&state, &request).unwrap();
-        assert!(matches!(result, AuthState::Public));
+        let state = create_state(AuthConfig::None, Key::generate());
+        let request = request_with_cookie(None);
+        assert!(matches!(authenticate(&state, &request), AuthState::Public));
     }
 
     #[test]
-    fn authenticate_request_when_no_header() {
-        let state = create_state(AuthConfig::Some {
-            username: "user".to_string(),
-            password_hash: bcrypt::hash("pass", 4).unwrap(),
-        });
-        let request = create_request_with_auth(None);
-        let result = authenticate(&state, &request).unwrap();
-        assert!(matches!(result, AuthState::Request));
+    fn authenticate_unauthenticated_when_no_cookie() {
+        let state = create_state(some_auth(), Key::generate());
+        let request = request_with_cookie(None);
+        assert!(matches!(
+            authenticate(&state, &request),
+            AuthState::Unauthenticated
+        ));
     }
 
     #[test]
-    fn authenticate_success_with_valid_credentials() {
-        let password_hash = bcrypt::hash("password", 4).unwrap();
-        let state = create_state(AuthConfig::Some {
-            username: "user".to_string(),
-            password_hash,
-        });
-        let credentials = BASE64_ENGINE.encode("user:password");
-        let request = create_request_with_auth(Some(&format!("Basic {credentials}")));
-        let result = authenticate(&state, &request).unwrap();
-        assert!(matches!(result, AuthState::Success));
+    fn authenticate_authenticated_with_valid_cookie() {
+        let key = Key::generate();
+        let state = create_state(some_auth(), key.clone());
+        let header = signed_header(&key, build_session_cookie());
+        let request = request_with_cookie(Some(&header));
+        assert!(matches!(
+            authenticate(&state, &request),
+            AuthState::Authenticated
+        ));
     }
 
     #[test]
-    fn authenticate_failed_with_wrong_scheme() {
-        let password_hash = bcrypt::hash("password", 4).unwrap();
-        let state = create_state(AuthConfig::Some {
-            username: "user".to_string(),
-            password_hash,
-        });
-        let credentials = BASE64_ENGINE.encode("user:password");
-        let request = create_request_with_auth(Some(&format!("Bearer {credentials}")));
-        let result = authenticate(&state, &request).unwrap();
-        assert!(matches!(result, AuthState::Failed));
+    fn authenticate_unauthenticated_with_expired_cookie() {
+        let key = Key::generate();
+        let state = create_state(some_auth(), key.clone());
+        let expired = Cookie::build((SESSION_COOKIE, (Utc::now().timestamp() - 1).to_string()))
+            .path("/")
+            .build();
+        let header = signed_header(&key, expired);
+        let request = request_with_cookie(Some(&header));
+        assert!(matches!(
+            authenticate(&state, &request),
+            AuthState::Unauthenticated
+        ));
     }
 
     #[test]
-    fn authenticate_failed_with_wrong_username() {
-        let password_hash = bcrypt::hash("password", 4).unwrap();
-        let state = create_state(AuthConfig::Some {
-            username: "user".to_string(),
-            password_hash,
-        });
-        let credentials = BASE64_ENGINE.encode("wronguser:password");
-        let request = create_request_with_auth(Some(&format!("Basic {credentials}")));
-        let result = authenticate(&state, &request).unwrap();
-        assert!(matches!(result, AuthState::Failed));
+    fn authenticate_unauthenticated_with_tampered_cookie() {
+        let state = create_state(some_auth(), Key::generate());
+        // A cookie that was never signed with our key.
+        let header = format!("{SESSION_COOKIE}=9999999999");
+        let request = request_with_cookie(Some(&header));
+        assert!(matches!(
+            authenticate(&state, &request),
+            AuthState::Unauthenticated
+        ));
     }
 
     #[test]
-    fn authenticate_failed_with_wrong_password() {
-        let password_hash = bcrypt::hash("password", 4).unwrap();
-        let state = create_state(AuthConfig::Some {
-            username: "user".to_string(),
-            password_hash,
-        });
-        let credentials = BASE64_ENGINE.encode("user:wrongpassword");
-        let request = create_request_with_auth(Some(&format!("Basic {credentials}")));
-        let result = authenticate(&state, &request).unwrap();
-        assert!(matches!(result, AuthState::Failed));
-    }
-
-    #[test]
-    fn authenticate_failed_with_malformed_credentials() {
-        let password_hash = bcrypt::hash("password", 4).unwrap();
-        let state = create_state(AuthConfig::Some {
-            username: "user".to_string(),
-            password_hash,
-        });
-        // Missing colon separator
-        let credentials = BASE64_ENGINE.encode("userpassword");
-        let request = create_request_with_auth(Some(&format!("Basic {credentials}")));
-        let result = authenticate(&state, &request).unwrap();
-        assert!(matches!(result, AuthState::Failed));
+    fn authenticate_unauthenticated_with_cookie_signed_by_other_key() {
+        let state = create_state(some_auth(), Key::generate());
+        let other_key = Key::generate();
+        let header = signed_header(&other_key, build_session_cookie());
+        let request = request_with_cookie(Some(&header));
+        assert!(matches!(
+            authenticate(&state, &request),
+            AuthState::Unauthenticated
+        ));
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -2,4 +2,6 @@ mod config;
 mod middleware;
 
 pub use config::AuthConfig;
-pub use middleware::{AuthState, auth_middleware_fn, authenticate};
+pub use middleware::{
+    AuthState, SESSION_COOKIE, auth_middleware_fn, authenticate, build_session_cookie,
+};

--- a/src/handlers/book.rs
+++ b/src/handlers/book.rs
@@ -10,6 +10,7 @@ use tracing::error;
 
 use crate::VERSION;
 use crate::assets::assets_version;
+use crate::auth::AuthConfig;
 use crate::models::Book;
 use crate::state::AppState;
 
@@ -19,6 +20,7 @@ struct BookTemplate<'a> {
     book: &'a Book,
     version: &'static str,
     assets_version: &'static str,
+    auth_enabled: bool,
 }
 
 pub async fn show_book_route(
@@ -39,6 +41,7 @@ pub async fn show_book_route(
         book,
         version: VERSION,
         assets_version: assets_version(),
+        auth_enabled: matches!(state.auth_config, AuthConfig::Some { .. }),
     };
     let rendered = match template.render() {
         Ok(html) => html,

--- a/src/handlers/index.rs
+++ b/src/handlers/index.rs
@@ -10,6 +10,7 @@ use tracing::error;
 
 use crate::VERSION;
 use crate::assets::assets_version;
+use crate::auth::AuthConfig;
 use crate::models::Book;
 use crate::state::AppState;
 
@@ -21,6 +22,7 @@ struct IndexTemplate<'a> {
     scanned_at: String,
     version: &'static str,
     assets_version: &'static str,
+    auth_enabled: bool,
 }
 
 pub async fn index_route(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -36,6 +38,7 @@ pub async fn index_route(State(state): State<Arc<AppState>>) -> impl IntoRespons
         scanned_at: scan.scanned_at.to_rfc2822(),
         version: VERSION,
         assets_version: assets_version(),
+        auth_enabled: matches!(state.auth_config, AuthConfig::Some { .. }),
     };
     let rendered = match t.render() {
         Ok(html) => html,

--- a/src/handlers/login.rs
+++ b/src/handlers/login.rs
@@ -1,0 +1,186 @@
+use std::sync::Arc;
+
+use askama::Template;
+use axum::{
+    Form,
+    extract::{Query, Request, State},
+    response::{Html, IntoResponse, Redirect, Response},
+};
+use cookie::{Cookie, CookieJar, time::Duration};
+use http::{HeaderValue, StatusCode, header};
+use serde::Deserialize;
+use tracing::error;
+
+use crate::VERSION;
+use crate::assets::assets_version;
+use crate::auth::{AuthConfig, AuthState, SESSION_COOKIE, authenticate, build_session_cookie};
+use crate::state::AppState;
+
+#[derive(Template)]
+#[template(path = "login.html")]
+struct LoginTemplate {
+    version: &'static str,
+    assets_version: &'static str,
+    error: bool,
+    next: String,
+}
+
+fn default_next() -> String {
+    "/".to_string()
+}
+
+#[derive(Deserialize)]
+pub struct LoginQuery {
+    #[serde(default = "default_next")]
+    next: String,
+}
+
+#[derive(Deserialize)]
+pub struct LoginForm {
+    username: String,
+    password: String,
+    #[serde(default = "default_next")]
+    next: String,
+}
+
+/// Check submitted credentials against the configured ones. When no credentials
+/// are configured every request is already public, so anything is accepted.
+pub fn verify_credentials(auth: &AuthConfig, username: &str, password: &str) -> bool {
+    match auth {
+        AuthConfig::None => true,
+        AuthConfig::Some {
+            username: expected_user,
+            password_hash,
+        } => username == expected_user && bcrypt::verify(password, password_hash).unwrap_or(false),
+    }
+}
+
+/// Constrain a post-login redirect target to a local path, blocking open
+/// redirects to absolute URLs or protocol-relative `//host` targets.
+fn safe_next(next: &str) -> String {
+    if next.starts_with('/') && !next.starts_with("//") {
+        next.to_string()
+    } else {
+        "/".to_string()
+    }
+}
+
+fn render_login(error: bool, next: &str) -> Response {
+    let template = LoginTemplate {
+        version: VERSION,
+        assets_version: assets_version(),
+        error,
+        next: safe_next(next),
+    };
+    match template.render() {
+        Ok(html) => {
+            let status = if error {
+                StatusCode::UNAUTHORIZED
+            } else {
+                StatusCode::OK
+            };
+            (status, Html(html)).into_response()
+        }
+        Err(err) => {
+            error!(%err, "failed to render login");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// Attach a freshly-signed session cookie to a response.
+fn set_session_cookie(response: &mut Response, state: &Arc<AppState>) {
+    let mut jar = CookieJar::new();
+    jar.signed_mut(&state.key).add(build_session_cookie());
+    for cookie in jar.delta() {
+        if let Ok(value) = HeaderValue::from_str(&cookie.encoded().to_string()) {
+            response.headers_mut().append(header::SET_COOKIE, value);
+        }
+    }
+}
+
+/// `GET /login` — render the login form. Skips it (redirecting home) when auth
+/// is disabled or the visitor already holds a valid session.
+pub async fn login_route(
+    Query(query): Query<LoginQuery>,
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Response {
+    if matches!(state.auth_config, AuthConfig::None)
+        || matches!(authenticate(&state, &request), AuthState::Authenticated)
+    {
+        return Redirect::to(&safe_next(&query.next)).into_response();
+    }
+    render_login(false, &query.next)
+}
+
+/// `POST /login` — verify credentials and, on success, issue a session cookie.
+pub async fn login_submit_route(
+    State(state): State<Arc<AppState>>,
+    Form(form): Form<LoginForm>,
+) -> Response {
+    if !verify_credentials(&state.auth_config, &form.username, &form.password) {
+        return render_login(true, &form.next);
+    }
+    let mut response = Redirect::to(&safe_next(&form.next)).into_response();
+    set_session_cookie(&mut response, &state);
+    response
+}
+
+/// `POST /logout` — clear the session cookie and return to the login form.
+pub async fn logout_route() -> Response {
+    let removal = Cookie::build((SESSION_COOKIE, ""))
+        .path("/")
+        .max_age(Duration::ZERO)
+        .build();
+    let mut response = Redirect::to("/login").into_response();
+    if let Ok(value) = HeaderValue::from_str(&removal.encoded().to_string()) {
+        response.headers_mut().append(header::SET_COOKIE, value);
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn some_auth() -> AuthConfig {
+        AuthConfig::Some {
+            username: "alice".to_string(),
+            password_hash: bcrypt::hash("s3cret", 4).unwrap(),
+        }
+    }
+
+    #[test]
+    fn verify_credentials_accepts_correct_pair() {
+        assert!(verify_credentials(&some_auth(), "alice", "s3cret"));
+    }
+
+    #[test]
+    fn verify_credentials_rejects_wrong_password() {
+        assert!(!verify_credentials(&some_auth(), "alice", "nope"));
+    }
+
+    #[test]
+    fn verify_credentials_rejects_wrong_username() {
+        assert!(!verify_credentials(&some_auth(), "bob", "s3cret"));
+    }
+
+    #[test]
+    fn verify_credentials_public_when_unconfigured() {
+        assert!(verify_credentials(&AuthConfig::None, "", ""));
+    }
+
+    #[test]
+    fn safe_next_allows_local_paths() {
+        assert_eq!(safe_next("/book/abc"), "/book/abc");
+        assert_eq!(safe_next("/"), "/");
+    }
+
+    #[test]
+    fn safe_next_blocks_open_redirects() {
+        assert_eq!(safe_next("//evil.example"), "/");
+        assert_eq!(safe_next("https://evil.example"), "/");
+        assert_eq!(safe_next("javascript:alert(1)"), "/");
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 mod book;
 mod health;
 mod index;
+mod login;
 mod page;
 mod rescan;
 mod shuffle;
@@ -9,6 +10,7 @@ mod thumb;
 pub use book::show_book_route;
 pub use health::{Healthz, healthz_route};
 pub use index::index_route;
+pub use login::{login_route, login_submit_route, logout_route};
 pub use page::show_page_route;
 pub use rescan::rescan_books_route;
 pub use shuffle::{shuffle_book_route, shuffle_route};

--- a/src/handlers/thumb.rs
+++ b/src/handlers/thumb.rs
@@ -134,6 +134,7 @@ mod tests {
     fn state_without_scan() -> Arc<AppState> {
         Arc::new(AppState {
             auth_config: AuthConfig::None,
+            key: cookie::Key::generate(),
             data_dir: PathBuf::from("/tmp"),
             scan: Arc::new(RwLock::new(None)),
             seed: 0,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -50,6 +50,7 @@ mod tests {
     fn create_test_state(scan: Option<BookScan>) -> Arc<AppState> {
         Arc::new(AppState {
             auth_config: AuthConfig::None,
+            key: cookie::Key::generate(),
             data_dir: PathBuf::from("/tmp"),
             scan: Arc::new(RwLock::new(scan)),
             seed: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@ pub use assets::{APP_CSS, APP_JS, APPLE_TOUCH_ICON_PNG, FAVICON_PNG, FAVICON_SVG
 pub use auth::{AuthConfig, auth_middleware_fn};
 pub use error::{AppError, AppResult};
 pub use handlers::{
-    Healthz, healthz_route, index_route, rescan_books_route, show_book_route, show_page_route,
-    show_thumb_route, shuffle_book_route, shuffle_route,
+    Healthz, healthz_route, index_route, login_route, login_submit_route, logout_route,
+    rescan_books_route, show_book_route, show_page_route, show_thumb_route, shuffle_book_route,
+    shuffle_route,
 };
 pub use models::{Book, BookScan, Page, scan_books};
 pub use state::AppState;

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,11 @@ fn init_route(opts: &Opts) -> anyhow::Result<(Router, Arc<AppState>)> {
         .route("/shuffle/{id}", post(shuffle_book_route))
         .route("/shuffle", post(shuffle_route))
         .route("/", get(index_route))
+        // Page images and thumbnails are content, so they live behind the auth
+        // layer too. Cookie verification is cheap, so guarding every image
+        // request (unlike per-request bcrypt) is no longer a concern.
+        .route("/data/{id}", get(show_page_route))
+        .route("/thumb/{size}/{id}", get(show_thumb_route))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware_fn,
@@ -178,10 +183,6 @@ fn init_route(opts: &Opts) -> anyhow::Result<(Router, Arc<AppState>)> {
         // logged out.
         .route("/login", get(login_route).post(login_submit_route))
         .route("/logout", post(logout_route))
-        // to prevent timing attack, bcrypt is too slow
-        // protected by randomly-generated string as page ID instead
-        .route("/data/{id}", get(show_page_route))
-        .route("/thumb/{size}/{id}", get(show_thumb_route))
         .route("/healthz", get(healthz_route))
         .route("/assets/app.css", get(|| async { (CSS_HEADERS, APP_CSS) }))
         .route("/assets/app.js", get(|| async { (JS_HEADERS, APP_JS) }))
@@ -715,7 +716,15 @@ mod tests {
         let server = build_auth_server(false).await;
         let book = DATA_IDS[0];
 
-        for path in ["/".to_string(), format!("/book/{book}")] {
+        for path in [
+            "/".to_string(),
+            format!("/book/{book}"),
+            // Page images and thumbnails are content too, so they sit behind the
+            // login as well. The middleware runs before the handler, so a bogus
+            // id still redirects rather than 404ing.
+            format!("/data/{book}"),
+            format!("/thumb/md/{book}"),
+        ] {
             let res = server.get(&path).await;
             assert_eq!(303, res.status_code(), "GET {path}");
             let location = res.headers().get("location").unwrap().to_str().unwrap();
@@ -755,6 +764,10 @@ mod tests {
             303,
             server.post(&format!("/shuffle/{book}")).await.status_code()
         );
+        // Image routes let the request through to the handler: an unknown id
+        // 404s (rather than redirecting to login), proving auth passed.
+        assert_eq!(404, server.get("/data/deadbeef").await.status_code());
+        assert_eq!(404, server.get("/thumb/md/deadbeef").await.status_code());
     }
 
     // Error handling tests

--- a/src/main.rs
+++ b/src/main.rs
@@ -706,6 +706,57 @@ mod tests {
         assert_eq!(200, server.get("/assets/app.css").await.status_code());
     }
 
+    /// Every route behind the auth layer must refuse anonymous access: read
+    /// routes bounce to the login form, write routes are rejected with 401. This
+    /// guards against a route silently slipping out from under the middleware
+    /// (e.g. by being declared after `route_layer`).
+    #[tokio::test]
+    async fn auth_every_protected_route_rejects_anonymous() {
+        let server = build_auth_server(false).await;
+        let book = DATA_IDS[0];
+
+        for path in ["/".to_string(), format!("/book/{book}")] {
+            let res = server.get(&path).await;
+            assert_eq!(303, res.status_code(), "GET {path}");
+            let location = res.headers().get("location").unwrap().to_str().unwrap();
+            assert!(location.starts_with("/login"), "GET {path} -> {location}");
+        }
+
+        for path in [
+            "/rescan".to_string(),
+            "/shuffle".to_string(),
+            format!("/shuffle/{book}"),
+        ] {
+            let res = server.post(&path).await;
+            assert_eq!(401, res.status_code(), "POST {path}");
+        }
+    }
+
+    /// The flip side: with a valid session every protected route is reachable
+    /// (no redirect to login, no 401).
+    #[tokio::test]
+    async fn auth_every_protected_route_reachable_when_logged_in() {
+        let server = build_auth_server(true).await;
+        server
+            .post("/login")
+            .form(&[("username", "user"), ("password", "password")])
+            .await;
+        let book = DATA_IDS[0];
+
+        assert_eq!(200, server.get("/").await.status_code());
+        assert_eq!(
+            200,
+            server.get(&format!("/book/{book}")).await.status_code()
+        );
+        // Write routes succeed and redirect (303), rather than being blocked.
+        assert_eq!(303, server.post("/rescan").await.status_code());
+        assert_eq!(303, server.post("/shuffle").await.status_code());
+        assert_eq!(
+            303,
+            server.post(&format!("/shuffle/{book}")).await.status_code()
+        );
+    }
+
     // Error handling tests
     #[tokio::test]
     async fn book_not_found() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use axum::{
     routing::{get, post},
 };
 use clap::{Parser, Subcommand, ValueEnum};
+use cookie::Key;
 use http::header;
 use parking_lot::RwLock;
 use tokio::{
@@ -31,9 +32,9 @@ use tracing_subscriber::{
 
 use comics::{
     APP_CSS, APP_JS, APPLE_TOUCH_ICON_PNG, AppState, AuthConfig, BCRYPT_COST, FAVICON_PNG,
-    FAVICON_SVG, VERSION, auth_middleware_fn, healthz_route, index_route, rescan_books_route,
-    scan_books, show_book_route, show_page_route, show_thumb_route, shuffle_book_route,
-    shuffle_route,
+    FAVICON_SVG, VERSION, auth_middleware_fn, healthz_route, index_route, login_route,
+    login_submit_route, logout_route, rescan_books_route, scan_books, show_book_route,
+    show_page_route, show_thumb_route, shuffle_book_route, shuffle_route,
 };
 
 // Assets are fingerprinted in the URL (`?v=<hash>`), so they can be cached
@@ -60,10 +61,10 @@ const PNG_HEADERS: AssetHeaders = [
 #[derive(Parser, Debug)]
 #[command(author, version=VERSION, about, long_about=None)]
 struct Opts {
-    /// Username for basic authentication
+    /// Username for the login form
     #[arg(long, env = "AUTH_USERNAME")]
     auth_username: Option<String>,
-    /// Hashed password for basic authentication
+    /// Hashed password for the login form
     #[arg(long, env = "AUTH_PASSWORD_HASH")]
     auth_password_hash: Option<String>,
     /// Bind host & port
@@ -150,6 +151,7 @@ fn init_route(opts: &Opts) -> anyhow::Result<(Router, Arc<AppState>)> {
             },
             _ => AuthConfig::None,
         },
+        key: Key::generate(),
         data_dir: data_dir.clone(),
         scan: Arc::new(RwLock::new(None)),
         seed,
@@ -172,6 +174,10 @@ fn init_route(opts: &Opts) -> anyhow::Result<(Router, Arc<AppState>)> {
             state.clone(),
             auth_middleware_fn,
         ))
+        // Login/logout sit outside the auth layer so they stay reachable while
+        // logged out.
+        .route("/login", get(login_route).post(login_submit_route))
+        .route("/logout", post(logout_route))
         // to prevent timing attack, bcrypt is too slow
         // protected by randomly-generated string as page ID instead
         .route("/data/{id}", get(show_page_route))
@@ -338,12 +344,9 @@ async fn main() -> anyhow::Result<()> {
 mod tests {
     use crate::{Opts, init_route, spawn_initial_scan};
     use axum_test::TestServer;
-    use base64::Engine;
     use clap::Parser as _;
     use comics::{BCRYPT_COST, VERSION};
     use tokio::sync::oneshot;
-
-    const BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
 
     const DATA_IDS: [&str; 2] = [
         // Netherworld Nomads Journey to the Jade Jungle
@@ -556,48 +559,17 @@ mod tests {
         assert_eq!(200, res.status_code());
     }
 
-    #[tokio::test]
-    async fn auth() {
-        use std::{thread, time};
-
-        let (tx, _) = oneshot::channel::<()>();
-        let mut opts = Opts::parse_from([
-            "comics",
-            "--data-dir",
-            "./fixtures/data",
-            "--auth-username",
-            "user",
-            "--auth-password-hash",
-            &bcrypt::hash("password", BCRYPT_COST).unwrap(),
-        ]);
-        opts.seed = Some(1);
-        let (router, state) = init_route(&opts).unwrap();
-        spawn_initial_scan(state, tx);
-
-        let server = TestServer::new(router.into_make_service());
-        for _ in 0..10 {
-            let res = server.get("/healthz").await;
-            if res.status_code() == 200 {
-                break;
-            }
-            thread::sleep(time::Duration::from_millis(100));
-        }
-
-        let credentials = BASE64_ENGINE.encode("user:password");
-        let res = server
-            .get("/")
-            .authorization(format!("Basic {credentials}"))
-            .await;
-        assert_eq!(200, res.status_code());
-    }
-
     #[test]
     fn version_is_set() {
         assert!(!VERSION.is_empty());
     }
 
-    // Authentication edge cases
-    async fn build_auth_server() -> TestServer {
+    // Authentication: form login backed by a signed session cookie.
+    const SESSION_COOKIE: &str = "comics_session";
+
+    /// Build a server with credentials configured. When `save_cookies` is set,
+    /// the test client persists cookies across requests like a browser would.
+    async fn build_auth_server(save_cookies: bool) -> TestServer {
         use std::{thread, time};
 
         let (tx, _) = oneshot::channel::<()>();
@@ -614,7 +586,10 @@ mod tests {
         let (router, state) = init_route(&opts).unwrap();
         spawn_initial_scan(state, tx);
 
-        let server = TestServer::new(router.into_make_service());
+        let mut server = TestServer::new(router.into_make_service());
+        if save_cookies {
+            server.save_cookies();
+        }
         for _ in 0..10 {
             let res = server.get("/healthz").await;
             if res.status_code() == 200 {
@@ -626,66 +601,109 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auth_invalid_base64() {
-        let server = build_auth_server().await;
-        let res = server
-            .get("/")
-            .authorization("Basic not-valid-base64!!!")
-            .await;
-        assert_eq!(500, res.status_code());
-    }
-
-    #[tokio::test]
-    async fn auth_malformed_credentials() {
-        let server = build_auth_server().await;
-        // Missing colon separator
-        let credentials = BASE64_ENGINE.encode("userpassword");
-        let res = server
-            .get("/")
-            .authorization(format!("Basic {credentials}"))
-            .await;
-        assert_eq!(401, res.status_code());
-    }
-
-    #[tokio::test]
-    async fn auth_wrong_method() {
-        let server = build_auth_server().await;
-        let credentials = BASE64_ENGINE.encode("user:password");
-        let res = server
-            .get("/")
-            .authorization(format!("Bearer {credentials}"))
-            .await;
-        assert_eq!(401, res.status_code());
-    }
-
-    #[tokio::test]
-    async fn auth_wrong_password() {
-        let server = build_auth_server().await;
-        let credentials = BASE64_ENGINE.encode("user:wrongpassword");
-        let res = server
-            .get("/")
-            .authorization(format!("Basic {credentials}"))
-            .await;
-        assert_eq!(401, res.status_code());
-    }
-
-    #[tokio::test]
-    async fn auth_wrong_username() {
-        let server = build_auth_server().await;
-        let credentials = BASE64_ENGINE.encode("wronguser:password");
-        let res = server
-            .get("/")
-            .authorization(format!("Basic {credentials}"))
-            .await;
-        assert_eq!(401, res.status_code());
-    }
-
-    #[tokio::test]
-    async fn auth_no_credentials() {
-        let server = build_auth_server().await;
+    async fn auth_unauthenticated_get_redirects_to_login() {
+        let server = build_auth_server(false).await;
         let res = server.get("/").await;
+        assert_eq!(303, res.status_code());
+        let location = res.headers().get("location").unwrap().to_str().unwrap();
+        assert!(location.starts_with("/login"));
+        assert!(location.contains("next="));
+    }
+
+    #[tokio::test]
+    async fn auth_unauthenticated_post_is_unauthorized() {
+        let server = build_auth_server(false).await;
+        let res = server.post("/rescan").await;
         assert_eq!(401, res.status_code());
-        assert!(res.headers().get("www-authenticate").is_some());
+    }
+
+    #[tokio::test]
+    async fn auth_login_page_is_public() {
+        let server = build_auth_server(false).await;
+        let res = server.get("/login").await;
+        assert_eq!(200, res.status_code());
+        assert!(res.text().contains("action=\"/login\""));
+    }
+
+    #[tokio::test]
+    async fn auth_login_success_sets_cookie_and_grants_access() {
+        let server = build_auth_server(true).await;
+        let res = server
+            .post("/login")
+            .form(&[
+                ("username", "user"),
+                ("password", "password"),
+                ("next", "/"),
+            ])
+            .await;
+        assert_eq!(303, res.status_code());
+        assert_eq!(
+            "/",
+            res.headers().get("location").unwrap().to_str().unwrap()
+        );
+        assert!(res.maybe_cookie(SESSION_COOKIE).is_some());
+
+        let res = server.get("/").await;
+        assert_eq!(200, res.status_code());
+        assert!(res.text().contains("2 book(s)"));
+    }
+
+    #[tokio::test]
+    async fn auth_login_wrong_password_is_unauthorized() {
+        let server = build_auth_server(false).await;
+        let res = server
+            .post("/login")
+            .form(&[("username", "user"), ("password", "nope")])
+            .await;
+        assert_eq!(401, res.status_code());
+        assert!(res.maybe_cookie(SESSION_COOKIE).is_none());
+        assert!(res.text().contains("帳號或密碼錯誤"));
+    }
+
+    #[tokio::test]
+    async fn auth_login_redirects_safely() {
+        // An off-site `next` is ignored in favour of the home page.
+        let server = build_auth_server(true).await;
+        let res = server
+            .post("/login")
+            .form(&[
+                ("username", "user"),
+                ("password", "password"),
+                ("next", "https://evil.example"),
+            ])
+            .await;
+        assert_eq!(303, res.status_code());
+        assert_eq!(
+            "/",
+            res.headers().get("location").unwrap().to_str().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_logout_clears_session() {
+        let server = build_auth_server(true).await;
+        server
+            .post("/login")
+            .form(&[("username", "user"), ("password", "password")])
+            .await;
+        assert_eq!(200, server.get("/").await.status_code());
+
+        let res = server.post("/logout").await;
+        assert_eq!(303, res.status_code());
+        assert_eq!(
+            "/login",
+            res.headers().get("location").unwrap().to_str().unwrap()
+        );
+
+        // Session is gone, so the protected page bounces to login again.
+        assert_eq!(303, server.get("/").await.status_code());
+    }
+
+    #[tokio::test]
+    async fn auth_public_routes_need_no_login() {
+        let server = build_auth_server(false).await;
+        assert_eq!(200, server.get("/healthz").await.status_code());
+        assert_eq!(200, server.get("/assets/app.css").await.status_code());
     }
 
     // Error handling tests

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
+use cookie::Key;
 use parking_lot::RwLock;
 use tokio::sync::Semaphore;
 
@@ -10,6 +11,9 @@ use crate::models::BookScan;
 #[derive(Clone)]
 pub struct AppState {
     pub auth_config: AuthConfig,
+    /// Secret key used to sign session cookies. Generated at startup, so a
+    /// restart invalidates every existing session.
+    pub key: Key,
     pub data_dir: PathBuf,
     pub scan: Arc<RwLock<Option<BookScan>>>,
     pub seed: u64,

--- a/templates/book.html
+++ b/templates/book.html
@@ -42,6 +42,11 @@
       <form method="POST" action="/shuffle/{{ book.id }}">
         <button class="tbtn" type="submit">Shuffle</button>
       </form>
+      {% if auth_enabled %}
+      <form method="POST" action="/logout">
+        <button class="tbtn" type="submit">Logout</button>
+      </form>
+      {% endif %}
     </div>
 
     <div class="viewer" id="viewer">

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,6 +59,11 @@
           <form method="POST" action="/shuffle">
             <button class="lbtn key" type="submit">Shuffle</button>
           </form>
+          {% if auth_enabled %}
+          <form method="POST" action="/logout">
+            <button class="lbtn" type="submit">Logout</button>
+          </form>
+          {% endif %}
           <span class="note">所蔵 {{ books.len() }} 冊</span>
         </div>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Sign in | Comics {{ version }}</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // set theme before paint to avoid a flash of the wrong palette
+      (function () {
+        var t =
+          localStorage.getItem("comics-theme") ||
+          (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+        document.documentElement.setAttribute("data-theme", t);
+      })();
+    </script>
+    <link rel="preconnect" href="https://fonts.bunny.net" />
+    <link
+      href="https://fonts.bunny.net/css?family=hanken-grotesk:400,500,600|shippori-mincho:500,700"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v={{ assets_version }}" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v={{ assets_version }}" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v={{ assets_version }}" />
+    <link href="/assets/app.css?v={{ assets_version }}" rel="stylesheet" />
+    <script src="/assets/app.js?v={{ assets_version }}" defer></script>
+  </head>
+
+  <body>
+    <main class="login">
+      <div class="loginbox">
+        <div class="brand">
+          <div class="mark"></div>
+          <div class="spine">漫画書架<span class="en">／ COMICS</span></div>
+        </div>
+        {% if error %}
+        <div class="err">帳號或密碼錯誤</div>
+        {% endif %}
+        <form method="POST" action="/login">
+          <input type="hidden" name="next" value="{{ next }}" />
+          <label>
+            Username
+            <input name="username" autocomplete="username" autofocus required />
+          </label>
+          <label>
+            Password
+            <input name="password" type="password" autocomplete="current-password" required />
+          </label>
+          <button class="lbtn key" type="submit">Sign in</button>
+        </form>
+      </div>
+      <button class="themebtn" id="theme" type="button" title="Toggle theme" aria-label="Toggle theme">◐</button>
+    </main>
+  </body>
+</html>

--- a/vendor/assets/app.css
+++ b/vendor/assets/app.css
@@ -305,3 +305,15 @@ html[data-theme="dark"] .progress i { box-shadow: 0 0 10px rgba(232, 84, 63, 0.6
   .thumbs { max-width: 38%; }
   .counter { font-size: 13px; }
 }
+
+/* login */
+.login { min-height: 100vh; display: grid; place-items: center; padding: 24px; position: relative; }
+.loginbox { width: 100%; max-width: 320px; }
+.loginbox .brand { display: flex; align-items: center; gap: 12px; margin-bottom: 28px; }
+.loginbox form { display: flex; flex-direction: column; gap: 16px; }
+.loginbox label { display: flex; flex-direction: column; gap: 6px; font-size: 11px; letter-spacing: 2px; text-transform: uppercase; color: var(--muted); }
+.loginbox input { font-family: var(--font-sans); font-size: 15px; color: var(--ink); background: var(--panel); border: 1px solid var(--rule); padding: 11px 14px; transition: border-color 0.2s ease; }
+.loginbox input:focus { outline: none; border-color: var(--vermilion); }
+.loginbox .lbtn { margin-top: 4px; text-align: center; }
+.loginbox .err { background: var(--vermilion); color: #fff; font-size: 13px; padding: 10px 14px; margin-bottom: 18px; }
+.login .themebtn { position: absolute; top: 18px; right: 18px; width: 34px; height: 34px; font-size: 16px; }


### PR DESCRIPTION
## Summary

Replace HTTP Basic Auth for the GUI with a form-based login backed by a stateless, signed session cookie, mirroring [Syncthing's v1.26 change](https://github.com/syncthing/syncthing/issues/4137). Basic Auth had two long-standing problems:

- **Performance**: bcrypt ran on *every* request (intentionally expensive — painful on low-powered hardware like NAS/Raspberry Pi).
- **UX**: the browser's native credential dialog plays badly with password managers and offers no logout.

## Changes

- **`GET`/`POST /login`** — render the form and verify credentials once with bcrypt, issuing a signed `comics_session` cookie (`HttpOnly`, `SameSite=Lax`, `Path=/`, 7-day expiry enforced server-side via an embedded timestamp).
- **`POST /logout`** — clear the cookie.
- **Auth middleware** — now verifies the cookie (cheap) instead of bcrypt per request; unauthenticated `GET`s bounce to `/login?next=<path>`, writes get `401`. `next` is constrained to local paths to block open redirects.
- A random signing key is generated at startup, so a restart invalidates all sessions (no server-side session store).
- New `templates/login.html`; a conditional Logout button on the index and reader pages.
- Credential configuration (`AUTH_USERNAME` / `AUTH_PASSWORD_HASH` / `hash-password`) is unchanged.

Dependency: adds `cookie` (signed + percent-encode); no `axum-extra`/`time` needed.

## Testing

- `cargo nextest run` — 64 tests pass, including rewritten integration tests (redirect, cookie issuance, wrong-password 401, logout, open-redirect protection, public routes).
- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo deny check` (advisories/bans) all clean.
- Manual end-to-end smoke test against a running server (login → access → logout flow, cookie attributes, public assets).

A design spec is included under `docs/superpowers/specs/`.

## Out of scope (YAGNI)

No Basic Auth compatibility mode, no "remember me" checkbox, no configurable TTL, no session revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)