### PR TITLE
fix: keep reader bars in viewport on iOS/iPadOS Safari

### DIFF
--- a/templates/book.html
+++ b/templates/book.html
@@ -5,7 +5,7 @@
       {{ book.title }} ({{ book.pages.len() }}P) | Comics {{ version }}
     </title>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <script>
       (function () {
         var t =

--- a/vendor/assets/app.css
+++ b/vendor/assets/app.css
@@ -171,13 +171,17 @@ h1 .dot { color: var(--vermilion); }
 
 /* ============================================================== READER */
 
-body.reader { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
+/* dvh tracks the *visible* viewport so iOS/iPadOS Safari's expanding/collapsing
+   toolbars can't push the topbar or rail outside the visible area (100vh maps to
+   the largest viewport and leaves the bottom rail off-screen while chrome is up). */
+body.reader { display: flex; flex-direction: column; height: 100dvh; overflow: hidden; }
 
 .topbar {
   display: flex;
   align-items: center;
   gap: 14px;
   padding: 12px 22px;
+  padding-top: calc(12px + env(safe-area-inset-top));
   border-bottom: 1px solid var(--rule);
   background: var(--paper);
   z-index: 5;
@@ -244,7 +248,7 @@ body.reader { display: flex; flex-direction: column; height: 100vh; overflow: hi
 /* paged mode: only the current page, centered, letterboxed in the stage */
 body[data-mode="paged"] .pages { display: grid; place-items: center; }
 body[data-mode="paged"] .pg.is-current { display: block; max-width: 100%; max-height: 100%; }
-body[data-mode="paged"] .pg.is-current img { max-width: 100%; max-height: calc(100vh - 130px); width: auto; height: auto; box-shadow: var(--shadow); }
+body[data-mode="paged"] .pg.is-current img { max-width: 100%; max-height: calc(100dvh - 130px); width: auto; height: auto; box-shadow: var(--shadow); }
 
 /* scroll mode: continuous vertical column */
 body[data-mode="scroll"] .pages { display: flex; flex-direction: column; align-items: center; gap: 16px; overflow-y: auto; padding: 22px 12px 60px; }
@@ -276,7 +280,7 @@ body[data-mode="scroll"] .zone { display: none; }
 @keyframes hintflash { 0%, 100% { opacity: 0; } 30%, 60% { opacity: 0.9; } }
 body.hint .zone span { animation: hintflash 1.9s ease; }
 
-.rail { border-top: 1px solid var(--rule); background: var(--paper); padding: 10px 16px; display: flex; align-items: center; gap: 14px; }
+.rail { border-top: 1px solid var(--rule); background: var(--paper); padding: 10px 16px; padding-bottom: calc(10px + env(safe-area-inset-bottom)); display: flex; align-items: center; gap: 14px; }
 .progress { flex: 1; height: 4px; background: var(--rule); position: relative; }
 .progress i { position: absolute; left: 0; top: 0; bottom: 0; background: var(--vermilion); width: 0; transition: width 0.1s linear; }
 html[data-theme="dark"] .progress i { box-shadow: 0 0 10px rgba(232, 84, 63, 0.6); }


### PR DESCRIPTION
## Problem

The reader is a flex column pinned to `100vh` (`body.reader`). On iOS/iPadOS Safari, `vh` resolves against the **largest** viewport (toolbars collapsed). While the address bar/toolbar is expanded, the container is taller than the actually-visible area, so the bottom rail (and sometimes the top bar) is pushed outside the viewport and can't be tapped. Safari's chrome expanding/collapsing on scroll makes this offset shift continuously.

## Fix

- Switch the reader container height and the paged image `max-height` from `100vh` to `100dvh`. The dynamic viewport unit tracks the *visible* viewport, so the browser re-lays-out the flex column as the toolbar shows/hides — the top bar and rail stay on screen.
- Add `viewport-fit=cover` to the reader's viewport meta and apply `env(safe-area-inset-top)` / `env(safe-area-inset-bottom)` padding to the top bar and rail so they also clear the notch and home indicator.

This is the minimal CSS-only fix. A `visualViewport`-based JS fallback (write the measured height into a CSS variable) is a possible follow-up if any residual cases remain after real-device verification, but `dvh` (Safari 15.4+) covers the target devices.

## Testing

- `cargo nextest run` — 66 passed.
- No test or doc asserts on these CSS strings; CSS viewport behavior isn't covered by the Rust/snapbox suite, and the E2E spec scopes mobile-viewport testing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)