### PR TITLE
chore: group Dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,9 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      cargo:
+        patterns: ["*"]
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -14,6 +17,9 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      docker:
+        patterns: ["*"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -21,3 +27,6 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Mirror henry40408/lur by collapsing each ecosystem's weekly Dependabot updates into a single grouped PR.

## Changes

Add a `groups` block with `patterns: ["*"]` to every ecosystem in `.github/dependabot.yaml`:

- `cargo`
- `docker`
- `github-actions`

The existing weekly schedule, `open-pull-requests-limit: 10`, and 7-day cooldown are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)