### PR TITLE
ci: enforce clippy across all targets and fail on warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo clippy
+      - run: cargo clippy --all-targets -- -D warnings
 
   coverage:
     needs: [lint, check]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ All commands run from the repository root.
   - Single test: `cargo nextest run <test_name>` (e.g. `cargo nextest run auth_logout_clears_session`)
   - Integration tests live in `tests/integration_test.rs` and drive the compiled binary via `snapbox`.
 - Coverage (as CI runs it): `cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info`
-- Lint (must pass CI): `cargo fmt --check`, `cargo clippy`, `cargo deny check`
+- Lint (must pass CI): `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo deny check`
 - Format before committing: `cargo fmt`
 
 The lint config in `Cargo.toml` denies `unsafe_code` and `unexpected_cfgs` and turns on a large set of pedantic Clippy lints — expect `cargo clippy` to be strict.


### PR DESCRIPTION
## What

Enforce the existing Clippy/rustc lint configuration in CI.

The `[lints.rust]` / `[lints.clippy]` set in `Cargo.toml` was advisory only —
CI ran a bare `cargo clippy`, so warnings never failed the build. This changes
the CI step to `cargo clippy --all-targets -- -D warnings`, so the lint set is
actually gated (and test/example targets are linted too).

## Why

Part of standardizing lint enforcement across the Rust projects. `comics`
already had the richest lint set but was the only project not failing CI on
clippy warnings.

## Notes

- No source changes — the crate already passes `cargo clippy --all-targets -- -D warnings` locally.
- `CLAUDE.md` lint-command reference updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
