### PR TITLE
ci: drop Windows from check matrix and parallelize gating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,24 @@ jobs:
           tool: cargo-deny@0.18.9
       - run: cargo deny check
 
+  # Linux clippy. This is the hard gate that coverage/e2e wait on — kept
+  # ubuntu-only so the (slower) macOS portability check below never sits on
+  # the critical path.
   check:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo clippy --all-targets -- -D warnings
+
+  # macOS portability sanity check. Runs independently and still fails the
+  # workflow on a regression, but does not block coverage/e2e. Windows was
+  # dropped from the matrix: comics ships only as a Linux Docker image
+  # (linux/amd64, linux/arm64 via distroless), so a Windows build had no
+  # deployment value and was the slowest leg in the matrix.
+  check-cross:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0


### PR DESCRIPTION
## What

Comics CI currently runs `cargo clippy` across a 3-OS matrix (`ubuntu`, `windows`, `macos`), and `coverage` + `e2e` gate on that whole matrix via `needs: [lint, check]`. Windows is the slowest leg, and `coverage`/`e2e` — which only run on Linux and recompile from scratch — wait for it before starting.

## Changes

- **Drop `windows-latest`.** Comics ships only as a Linux Docker image (`linux/amd64`, `linux/arm64` via distroless), so a Windows build carried no deployment value. This mirrors the decision already documented in `rdrs`'s CI.
- **Split the `check` matrix** into:
  - `check` — ubuntu-only clippy, the hard gate `coverage`/`e2e` wait on.
  - `check-cross` — macOS-only clippy, a portability sanity check that runs independently and never sits on the critical path (still fails the workflow on a regression).

## Effect

`coverage`/`e2e` now start once the fast Linux clippy passes instead of waiting for the slowest OS. `cargo fmt`, `cargo deny`, and Linux clippy remain hard gates. Estimated wall-clock drop from ~16 min to ~11–12 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)