### PR TITLE
ci: move workflow name above on: to match sibling repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
-on: [pull_request, push]
-
 name: CI
+
+on: [pull_request, push]
 
 jobs:
   lint:


### PR DESCRIPTION
## What

Cosmetic only. The `name: CI` field sat after the `on:` block; the sibling Rust repos (liftlog, lur, noadd, rdrs) declare `name:` as the first key. Move it to the top to align field ordering across repos.

The workflow display name is unchanged (`CI`) — no behavioral effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)