### PR TITLE
ci: run all jobs fully in parallel, drop the coverage/e2e gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,11 @@ jobs:
           tool: cargo-deny@0.18.9
       - run: cargo deny check
 
-  # Linux clippy. This is the hard gate that coverage/e2e wait on — kept
-  # ubuntu-only so the (slower) macOS portability check below never sits on
-  # the critical path.
+  # Linux clippy. Runs in parallel with everything else — coverage/e2e are no
+  # longer gated on it. On GitHub Actions a compile gate can't hand its build
+  # cache to downstream jobs, so gating would only serialize a second compile
+  # onto the critical path for no wall-clock win (the cheap checks, fmt/deny in
+  # lint, don't validate compilation anyway). Kept ubuntu-only; macOS is below.
   check:
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +42,6 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
 
   coverage:
-    needs: [lint, check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -55,7 +56,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   e2e:
-    needs: [lint, check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Why

`coverage` and `e2e` gated on `[lint, check]`. `check` is `clippy`, which **compiles**, and on GitHub Actions the build cache isn't shared across jobs — so the gate just serialized a **second full compile** onto the critical path while `coverage`/`e2e` recompile from scratch anyway. The cheap part of the gate (`lint` = `fmt` + `cargo-deny`) doesn't validate compilation, so it's weak fail-fast.

This is the same lesson applied to rdrs (#340): a Rust project has no cheap fail-fast gate, and a compile gate is pure serial overhead on the common success path.

## Change

Drop `needs` from `coverage` and `e2e`. All five jobs now run in parallel:

```
lint  check  check-cross  coverage  e2e     ← all start together
```

Wall-clock collapses to the slowest single job (~2m, vs ~check + e2e ≈ 3m25 before). Matches the fully-parallel shape now used in rdrs/liftlog/lur. Trade-off: fail-fast is given up — a broken push lets each job fail on its own compile, wasting runner minutes only on broken pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)