### PR TITLE
build: ship a static musl image and switch to mimalloc

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+      # No qemu: the Dockerfile builder is pinned to the native platform and zig
+      # cross-compiles both musl targets, so the arm64 image needs no emulation.
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
@@ -40,5 +41,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_VERSION=${{ steps.version.outputs.version }}
+          # Persist BuildKit layer cache across runs via the GitHub Actions cache
+          # backend. This caches image layers (apt install, cargo-zigbuild build,
+          # zig download) — not the in-Dockerfile cargo/target cache mounts, which
+          # are local to an ephemeral runner and don't survive between runs.
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "cookie",
  "http",
  "image",
+ "mimalloc",
  "parking_lot",
  "rand 0.10.1",
  "rayon",
@@ -1149,6 +1150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1205,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 cookie = { version = "0.18.1", default-features = false, features = ["signed", "percent-encode"] }
 http = "1.4.1"
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
+mimalloc = "0.1"
 parking_lot = "0.12.1"
 rand = "0.10.0"
 rayon = "1.12.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,58 @@
-# Stage 1: Chef - prepare recipe (runs on build platform)
-FROM --platform=$BUILDPLATFORM rust:1.96-bookworm AS chef
-RUN cargo install cargo-chef
+# syntax=docker/dockerfile:1
+
+# ---- build: cross-compile a static musl binary with cargo-zigbuild ----------
+# The builder is pinned to the native build platform; zig cross-compiles to the
+# target arch's musl triple, so no qemu emulation is needed — an arm64 image
+# builds at the host's native speed. The only C dependency is mimalloc, which
+# zig cc compiles from source; everything else (image codecs, bcrypt, xxhash) is
+# pure Rust, so no CMake or system libraries are required.
+FROM --platform=$BUILDPLATFORM rust:1.96-bookworm AS build
+
+# curl + xz fetch zig; that is the only build-time system dependency.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Zig 0.14.1 avoids the libc++-19 bindgen requirement that 0.15+ introduces.
+ARG ZIG_VERSION=0.14.1
+ARG ZIGBUILD_VERSION=0.22.3
+RUN cargo install cargo-zigbuild --version "${ZIGBUILD_VERSION}" --locked
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) zarch=x86_64 ;; \
+      aarch64) zarch=aarch64 ;; \
+      *) echo "unsupported build arch $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zarch}-linux-${ZIG_VERSION}.tar.xz" \
+      | tar -xJ -C /opt; \
+    ln -s "/opt/zig-${zarch}-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
 WORKDIR /app
-
-# Stage 2: Planner - create recipe.json
-FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
 
-# Stage 3: Builder - cross-compile for target platform
-FROM chef AS builder
-
-# Target platform args (set by docker buildx)
-ARG TARGETPLATFORM
+# Map Docker's TARGETARCH onto the Rust musl triple and build. `rustup target
+# add` runs after the source (and rust-toolchain.toml) is in place, so it
+# resolves against the pinned toolchain rather than the base image's default.
+ARG TARGETARCH
 ARG GIT_VERSION=dev
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    set -eux; \
+    case "$TARGETARCH" in \
+      amd64) target=x86_64-unknown-linux-musl ;; \
+      arm64) target=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported target arch $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "$target"; \
+    GIT_VERSION="${GIT_VERSION}" cargo zigbuild --release --target "$target"; \
+    install -Dm755 "target/${target}/release/comics" /out/comics
 
-# Install cross-compilation toolchain based on target
-RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") \
-            apt-get update && apt-get install -y gcc-aarch64-linux-gnu && \
-            rustup target add aarch64-unknown-linux-gnu \
-            ;; \
-        "linux/amd64") \
-            # Native build, no extra toolchain needed \
-            ;; \
-    esac
-
-# Configure cargo for cross-compilation
-RUN mkdir -p .cargo && \
-    case "$TARGETPLATFORM" in \
-        "linux/arm64") \
-            echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml && \
-            echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml \
-            ;; \
-    esac
-
-# Set the Rust target based on platform
-RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") echo "aarch64-unknown-linux-gnu" > /tmp/rust_target ;; \
-        "linux/amd64") echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
-        *) echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
-    esac
-
-COPY --from=planner /app/recipe.json recipe.json
-
-# Cook dependencies with target
-RUN RUST_TARGET=$(cat /tmp/rust_target) && \
-    cargo chef cook --release --recipe-path recipe.json --target $RUST_TARGET
-
-COPY . .
-
-# Build the application (build.rs uses GIT_VERSION env var)
-RUN RUST_TARGET=$(cat /tmp/rust_target) && \
-    GIT_VERSION=${GIT_VERSION} cargo build --release --target $RUST_TARGET && \
-    cp target/$RUST_TARGET/release/comics /app/comics
-
-# Stage 4: Runtime
-FROM gcr.io/distroless/cc-debian12
-
-COPY --from=builder /app/comics /comics
+# ---- runtime: minimal static image (CA certs + tzdata, no shell) ------------
+# distroless/static (not :nonroot) keeps the root runtime user the previous
+# distroless/cc image defaulted to, so a bind-mounted data/cache dir stays
+# writable without a permissions change.
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /out/comics /comics
 
 ENV BIND=0.0.0.0:3000
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.96.0"
 components = ["clippy", "rustfmt"]
-targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
+targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,12 @@ use comics::{
     show_page_route, show_thumb_route, shuffle_book_route, shuffle_route,
 };
 
+// The release image links musl, whose default allocator is markedly slower than
+// glibc's under the concurrent, allocation-heavy work this server does (rayon
+// scans, on-demand image decoding for thumbnails). mimalloc restores throughput.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // Assets are fingerprinted in the URL (`?v=<hash>`), so they can be cached
 // forever; the URL changes whenever the content changes.
 type AssetHeaders = [(header::HeaderName, &'static str); 2];


### PR DESCRIPTION
## What

Migrate the release image from a glibc dynamic build to a fully static
musl binary, and add mimalloc as the global allocator.

## Changes

- **Dockerfile**: replace the `cargo-chef` + glibc cross-build with
  `cargo-zigbuild` targeting `x86_64`/`aarch64-unknown-linux-musl`, and run
  on `distroless/static-debian12` instead of `distroless/cc-debian12`. zig
  cross-compiles both arches from the native builder. The runtime image
  shrinks to ~2 MB and is fully static.
- **`.github/workflows/docker.yaml`**: drop `setup-qemu-action` — zig
  cross-compiles, so no emulation is needed. Existing GHA layer cache kept.
- **`rust-toolchain.toml`**: switch the pre-installed `targets` from the
  `-gnu` triples (which only served the old Docker cross-build) to the
  `-musl` ones.
- **mimalloc**: comics is otherwise pure Rust; mimalloc (its only C
  dependency, compiled from source by zig cc — still no CMake) is added as
  the global allocator to recover the throughput musl's default allocator
  loses under the concurrent, allocation-heavy scan and thumbnail work.

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- Docker build succeeds for both `linux/amd64` and `linux/arm64`.
- The static binary runs in the no-libc `distroless/static` base, serves
  `/healthz`, and scans the fixture data; image is ~2 MB, binary is
  `statically linked, stripped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)