### PR TITLE
fix(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "askama"


### PR DESCRIPTION
## Summary

`anyhow 1.0.102` is affected by [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) — unsoundness in `Error::downcast_mut()` when an error is augmented via `Error::context` and later downcast, resulting in undefined behavior.

This advisory makes `cargo deny check advisories` (the `lint` CI job) fail on `main`, which in turn blocks unrelated Dependabot PRs (#350, #351).

## Change

- Bump `anyhow` `1.0.102` → `1.0.103` in `Cargo.lock` only (advisory patched in `>= 1.0.103`).
- `Cargo.toml` is unchanged; no code changes.

Verified locally: `cargo deny check advisories` → `advisories ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)