### PR TITLE
fix(deps): temporarily ignore RUSTSEC-2026-0204 to unblock CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,4 +11,10 @@ allow = [
 
 [advisories]
 version = 2
-ignore = []
+ignore = [
+  # RUSTSEC-2026-0204: crossbeam-epoch <0.9.20 invalid pointer dereference in
+  # fmt::Pointer impl (pulled in transitively via rayon). Fixed in 0.9.20, but
+  # that release is <7 days old and blocked by our dependency cooldown policy.
+  # Temporary ignore to unblock CI; remove once we upgrade to >=0.9.20.
+  "RUSTSEC-2026-0204",
+]


### PR DESCRIPTION
## Problem

`cargo deny check` fails on **every** open PR (including all Dependabot dependency-update PRs), blocking merges:

```
error[vulnerability]: Invalid pointer dereference in `fmt::Pointer` impl
  crossbeam-epoch 0.9.18
  ID: RUSTSEC-2026-0204
  Solution: Upgrade to >=0.9.20

  crossbeam-epoch v0.9.18
    └── crossbeam-deque v0.8.6
        └── rayon-core v1.13.0
            └── rayon v1.12.0
                └── comics v0.0.0-dev
```

`crossbeam-epoch 0.9.18` is pulled in transitively via `rayon`. The advisory is a pre-existing issue on `main`, not introduced by any of the update PRs, so those PRs cannot self-heal.

## Why not just upgrade?

The fix requires `crossbeam-epoch >= 0.9.20`, but `0.9.20` was published on 2026-07-06 — less than 7 days ago — and is held back by our dependency cooldown policy.

## This change

Add a **temporary** advisory ignore for `RUSTSEC-2026-0204` in `deny.toml` to unblock CI. A follow-up issue tracks upgrading to `>=0.9.20` and removing this ignore once the release clears the 7-day cooldown window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)