### PR TITLE
chore(deps): bump crossbeam-epoch past RUSTSEC-2026-0204 cooldown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -12,9 +12,4 @@ allow = [
 [advisories]
 version = 2
 ignore = [
-  # RUSTSEC-2026-0204: crossbeam-epoch <0.9.20 invalid pointer dereference in
-  # fmt::Pointer impl (pulled in transitively via rayon). Fixed in 0.9.20, but
-  # that release is <7 days old and blocked by our dependency cooldown policy.
-  # Temporary ignore to unblock CI; remove once we upgrade to >=0.9.20.
-  "RUSTSEC-2026-0204",
 ]


### PR DESCRIPTION
## Summary

Bumps `crossbeam-epoch` from 0.9.18 to 0.9.20 to pick up the fix for **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Pointer` impl, pulled in transitively via `rayon`).

The 0.9.20 release has now cleared the 7-day dependency cooldown, so the temporary advisory ignore in `deny.toml` — and its explanatory comment — is removed.

## Changes

- `Cargo.lock`: `crossbeam-epoch` 0.9.18 → 0.9.20
- `deny.toml`: drop the `RUSTSEC-2026-0204` ignore entry and its explanatory comment

## Verification

- `cargo nextest run` — 66 passed
- `cargo deny check advisories` — advisories ok

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)