### PR TITLE
chore: change default bind to 0.0.0.0:8080

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Comics is a self-hosted file server for comic books, built with Rust and Axum. I
 All commands run from the repository root.
 
 - Build: `cargo build` (release: `cargo build --release`)
-- Run the server: `cargo run` (serves `./data` on `127.0.0.1:3000` by default)
+- Run the server: `cargo run` (serves `./data` on `0.0.0.0:8080` by default)
 - Tests: `cargo nextest run` (per the user's global rule, not `cargo test`)
   - Single test: `cargo nextest run <test_name>` (e.g. `cargo nextest run auth_logout_clears_session`)
   - Integration tests live in `tests/integration_test.rs` and drive the compiled binary via `snapbox`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /out/comics /comics
 
-ENV BIND=0.0.0.0:3000
+ENV BIND=0.0.0.0:8080
 
-EXPOSE 3000
+EXPOSE 8080
 
 ENTRYPOINT ["/comics"]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 | --- | --- | --- |
 | `AUTH_USERNAME` | Username for the login form | _(none)_ |
 | `AUTH_PASSWORD_HASH` | Hashed password for the login form | _(none)_ |
-| `BIND` | Bind host & port | `127.0.0.1:3000` |
+| `BIND` | Bind host & port | `0.0.0.0:8080` |
 | `DATA_DIR` | Data directory | `./data` |
 | `CACHE_DIR` | Directory for cached thumbnails | `comics-thumbs` under the system temp dir |
 | `LOG_FORMAT` | Log format (`full`, `compact`, `pretty`, `json`) | `full` |
@@ -80,7 +80,7 @@ Navigate to the project directory in your terminal or command line and enter:
 ./comics
 ```
 
-Now, open your web browser and head to http://localhost:3000/ to view your comics.
+Now, open your web browser and head to http://localhost:8080/ to view your comics.
 
 ## Commands
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ struct Opts {
     #[arg(long, env = "AUTH_PASSWORD_HASH")]
     auth_password_hash: Option<String>,
     /// Bind host & port
-    #[arg(long, short = 'b', env = "BIND", default_value = "127.0.0.1:3000")]
+    #[arg(long, short = 'b', env = "BIND", default_value = "0.0.0.0:8080")]
     bind: String,
     /// Data directory
     #[arg(long, env = "DATA_DIR", default_value = "./data")]


### PR DESCRIPTION
## Summary

Changes the default `BIND` from `127.0.0.1:3000` to `0.0.0.0:8080`:

- **`0.0.0.0`** — listen on all interfaces, so a reverse proxy running in a separate container can reach it (loopback-only `127.0.0.1` is not reachable across container network namespaces).
- **`8080`** — avoid collisions with frontend dev servers that conventionally occupy port `3000`.

This aligns comics with the sibling services. `BIND` remains fully overridable.

## Changes

- `src/main.rs` — clap `default_value` for `BIND`
- `README.md` — env-var table + "open your browser" URL
- `CLAUDE.md` — dev-run default note
- `Dockerfile` — `ENV BIND=0.0.0.0:8080`, `EXPOSE 8080`

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build`
- End-to-end smoke test: with no `BIND` set, the server listens on `0.0.0.0:8080` (confirmed via `lsof`) and `curl /` returns `200`; an invalid `BIND` fails fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)