### PR TITLE
fix: default BIND to loopback (127.0.0.1:8080)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Comics is a self-hosted file server for comic books, built with Rust and Axum. I
 All commands run from the repository root.
 
 - Build: `cargo build` (release: `cargo build --release`)
-- Run the server: `cargo run` (serves `./data` on `0.0.0.0:8080` by default)
+- Run the server: `cargo run` (serves `./data` on `127.0.0.1:8080` by default)
 - Tests: `cargo nextest run` (per the user's global rule, not `cargo test`)
   - Single test: `cargo nextest run <test_name>` (e.g. `cargo nextest run auth_logout_clears_session`)
   - Integration tests live in `tests/integration_test.rs` and drive the compiled binary via `snapbox`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 | --- | --- | --- |
 | `AUTH_USERNAME` | Username for the login form | _(none)_ |
 | `AUTH_PASSWORD_HASH` | Hashed password for the login form | _(none)_ |
-| `BIND` | Bind host & port | `0.0.0.0:8080` |
+| `BIND` | Bind host & port (defaults to loopback; the container image sets `0.0.0.0:8080` so a reverse proxy can reach it) | `127.0.0.1:8080` |
 | `DATA_DIR` | Data directory | `./data` |
 | `CACHE_DIR` | Directory for cached thumbnails | `comics-thumbs` under the system temp dir |
 | `LOG_FORMAT` | Log format (`full`, `compact`, `pretty`, `json`) | `full` |

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,10 @@ struct Opts {
     /// Hashed password for the login form
     #[arg(long, env = "AUTH_PASSWORD_HASH")]
     auth_password_hash: Option<String>,
-    /// Bind host & port
-    #[arg(long, short = 'b', env = "BIND", default_value = "0.0.0.0:8080")]
+    /// Bind host & port. Defaults to loopback so a bare-metal run is not
+    /// exposed on all interfaces without opting in; the container image sets
+    /// `BIND=0.0.0.0:8080` so a reverse proxy can reach it.
+    #[arg(long, short = 'b', env = "BIND", default_value = "127.0.0.1:8080")]
     bind: String,
     /// Data directory
     #[arg(long, env = "DATA_DIR", default_value = "./data")]


### PR DESCRIPTION
## What

Change the compile-time default of `BIND` from `0.0.0.0:8080` to `127.0.0.1:8080` (loopback only).

## Why

The previous default bound all interfaces. A bare-metal run with nothing configured would listen on `0.0.0.0` — exposed to the network without a firewall. Binding loopback by default is secure-by-default; exposing on all interfaces now requires an explicit opt-in.

Container deployments are unaffected: the `Dockerfile` already sets `ENV BIND=0.0.0.0:8080`, and that env value is overridable at runtime via `docker run -e` or a compose `environment:` entry, so a reverse proxy in a separate container can still reach the server.

## Changes

- `src/main.rs`: default `127.0.0.1:8080` + doc comment.
- `README.md`, `CLAUDE.md`: default note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)