### PR TITLE
chore(docker): exclude .git and .github from the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
 data
 !data/.keep
 target
+
+# The image never needs git history: CI resolves `git describe` on the runner
+# and passes it in as the GIT_VERSION build arg. Keeping .git out of the context
+# stops every commit from invalidating the `COPY . .` layer (and the cargo build
+# behind it) even when no source file changed.
+.git
+.github


### PR DESCRIPTION
## Summary

The Docker image never needs git history. `.github/workflows/docker.yaml` resolves `git describe` on the runner and passes it in as the `GIT_VERSION` build arg; `build.rs` returns that value directly and never shells out to `git`.

But `.dockerignore` only excluded `data` and `target`, so `COPY . .` pulled the entire `.git` directory into the build stage:

| | size |
|---|---|
| `.git` | 12 MB |
| all tracked files | 5.3 MB |

Over two thirds of the build context was history that the build cannot use.

The real cost is caching: the `COPY . .` layer's cache key included `.git`, so **every commit invalidated that layer** — and the `cargo zigbuild --release` behind it — even when no source file changed. That defeats the `cache-from: type=gha` layer cache the workflow sets up.

## Changes

Add `.git` and `.github` to `.dockerignore`.

## Impact

- CI is unaffected: it already passes `GIT_VERSION` explicitly.
- The published image is unaffected either way — the distroless runtime stage only copies `/out/comics`, so no history was ever shipped.
- Only behaviour change: a local `docker build .` **without** `--build-arg GIT_VERSION=...` now falls back to `"unknown"`. Previously it attempted `git describe` inside the container, which would generally have failed on git's dubious-ownership check and landed on the same `"unknown"`.

## Test plan

- [ ] Docker workflow builds both `linux/amd64` and `linux/arm64` on merge to `main`
- [ ] The resulting image reports the version from `git describe`, not `unknown`

Not verified locally — no Docker daemon on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)