### PR TITLE
feat: add stateless CSRF origin guard

### DIFF
--- a/src/csrf.rs
+++ b/src/csrf.rs
@@ -1,0 +1,194 @@
+//! First-line CSRF defence: reject state-changing requests that a browser
+//! reports, or reveals, to be cross-site.
+//!
+//! This is a header-only check with no token and no state. It runs on every
+//! unsafe-method request across the whole router, but only ever *rejects* a
+//! request that is provably cross-site; anything it cannot classify is passed
+//! through, so it never breaks a legitimate caller:
+//!
+//! - **`Sec-Fetch-Site`** (sent by every current browser) is authoritative when
+//!   present. `same-origin`, `same-site`, and `none` (a direct navigation or a
+//!   user-typed URL) are allowed; only `cross-site` is rejected.
+//! - **`Origin`** is the fallback for the rare browser that omits
+//!   `Sec-Fetch-Site`. Its host is compared against the request's own `Host`;
+//!   a mismatch — or an opaque `Origin: null` — is rejected.
+//! - **Neither header** means a non-browser client (`curl`, a server-to-server
+//!   call). Those do not ride an ambient session cookie, so they are not
+//!   exposed to CSRF and are allowed through.
+//!
+//! Scheme and port are deliberately ignored in the `Origin`/`Host` comparison:
+//! behind a TLS-terminating reverse proxy the browser's `Origin` is `https://`
+//! while the forwarded `Host` carries no scheme, and the proxy commonly strips
+//! the port. Matching on host alone is what keeps the check working in that
+//! standard deployment without a configured public URL.
+
+use axum::{
+    extract::Request,
+    http::{Method, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+/// Reject a state-changing request that is provably cross-site. See the module
+/// docs for the classification. Safe methods (GET/HEAD/OPTIONS/TRACE) never
+/// change state and pass through untouched.
+pub async fn csrf_origin_guard(req: Request, next: Next) -> Response {
+    if is_safe(req.method()) || !is_cross_site(&req) {
+        return next.run(req).await;
+    }
+    StatusCode::FORBIDDEN.into_response()
+}
+
+/// Whether `method` cannot change server state and so needs no CSRF check.
+fn is_safe(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
+    )
+}
+
+/// Whether the request is one a browser has told us — via `Sec-Fetch-Site` or a
+/// mismatched `Origin` — is cross-site. A request a browser did not mark, and
+/// that carries no `Origin`, is treated as not-cross-site (a non-browser
+/// client); see the module docs.
+fn is_cross_site(req: &Request) -> bool {
+    let headers = req.headers();
+
+    // `Sec-Fetch-Site` is authoritative where the browser sends it.
+    if let Some(site) = headers.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
+        return site.eq_ignore_ascii_case("cross-site");
+    }
+
+    // Fall back to comparing the Origin's host with the request's own Host.
+    let Some(origin) = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok()) else {
+        // No Sec-Fetch-Site and no Origin → a non-browser client.
+        return false;
+    };
+    // `Origin: null` is opaque (a sandboxed iframe, a cross-origin redirect) and
+    // never legitimate for a state-changing request here.
+    if origin.eq_ignore_ascii_case("null") {
+        return true;
+    }
+    let Some(origin_host) = host_of(origin) else {
+        return true;
+    };
+    let request_host = headers
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(strip_port);
+    // A missing/garbled Host with a present Origin cannot be confirmed
+    // same-origin, so treat it as cross-site.
+    request_host != Some(origin_host)
+}
+
+/// The host of an `Origin` value (`scheme://host[:port]`), lower-cased and with
+/// any port removed. `None` when there is no `://` authority to read.
+fn host_of(origin: &str) -> Option<String> {
+    let authority = origin.split_once("://").map(|(_, rest)| rest)?;
+    Some(strip_port(authority).to_ascii_lowercase())
+}
+
+/// Strip a trailing `:port` from a host authority, leaving the host. Handles
+/// bracketed IPv6 literals (`[::1]:8080` → `[::1]`).
+fn strip_port(authority: &str) -> String {
+    if let Some(end) = authority
+        .strip_prefix('[')
+        .and_then(|_| authority.find(']'))
+    {
+        // Bracketed IPv6: keep through the closing bracket, drop any `:port`.
+        return authority[..=end].to_ascii_lowercase();
+    }
+    authority
+        .rsplit_once(':')
+        .map_or(authority, |(host, _)| host)
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+
+    fn req(method: Method, headers: &[(&str, &str)]) -> Request {
+        let mut b = Request::builder().method(method).uri("/anything");
+        for (k, v) in headers {
+            b = b.header(*k, *v);
+        }
+        b.body(Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn safe_methods_are_never_cross_site_checked() {
+        // Even an obviously cross-site GET passes — GET must not change state.
+        let r = req(Method::GET, &[("sec-fetch-site", "cross-site")]);
+        assert!(is_safe(r.method()));
+    }
+
+    #[test]
+    fn sec_fetch_site_is_authoritative() {
+        for allowed in ["same-origin", "same-site", "none", "SAME-ORIGIN"] {
+            assert!(
+                !is_cross_site(&req(Method::POST, &[("sec-fetch-site", allowed)])),
+                "{allowed} must be allowed"
+            );
+        }
+        assert!(is_cross_site(&req(
+            Method::POST,
+            &[("sec-fetch-site", "cross-site")]
+        )));
+        // It wins over a same-looking Origin/Host, in both directions.
+        assert!(is_cross_site(&req(
+            Method::POST,
+            &[
+                ("sec-fetch-site", "cross-site"),
+                ("origin", "https://app.example.com"),
+                ("host", "app.example.com"),
+            ]
+        )));
+    }
+
+    #[test]
+    fn origin_fallback_compares_host_ignoring_scheme_and_port() {
+        // TLS-terminating proxy: Origin is https://, Host has no scheme/port.
+        assert!(!is_cross_site(&req(
+            Method::POST,
+            &[
+                ("origin", "https://app.example.com"),
+                ("host", "app.example.com"),
+            ]
+        )));
+        // Port on the Origin, none on Host → still same host.
+        assert!(!is_cross_site(&req(
+            Method::POST,
+            &[("origin", "http://localhost:8080"), ("host", "localhost"),]
+        )));
+        // Genuine cross-origin.
+        assert!(is_cross_site(&req(
+            Method::POST,
+            &[
+                ("origin", "https://evil.example.com"),
+                ("host", "app.example.com"),
+            ]
+        )));
+        // Opaque origin.
+        assert!(is_cross_site(&req(
+            Method::POST,
+            &[("origin", "null"), ("host", "app.example.com")]
+        )));
+    }
+
+    #[test]
+    fn ipv6_literal_host_is_compared_without_its_port() {
+        assert!(!is_cross_site(&req(
+            Method::POST,
+            &[("origin", "http://[::1]:8080"), ("host", "[::1]")]
+        )));
+    }
+
+    #[test]
+    fn non_browser_client_without_headers_passes() {
+        // A curl / server-to-server call sends neither header and does not ride
+        // an ambient cookie, so it is not a CSRF vector.
+        assert!(!is_cross_site(&req(Method::POST, &[])));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod assets;
 pub mod auth;
+pub mod csrf;
 pub mod error;
 pub mod handlers;
 pub mod helpers;
@@ -8,6 +9,7 @@ pub mod state;
 
 pub use assets::{APP_CSS, APP_JS, APPLE_TOUCH_ICON_PNG, FAVICON_PNG, FAVICON_SVG, assets_version};
 pub use auth::{AuthConfig, auth_middleware_fn};
+pub use csrf::csrf_origin_guard;
 pub use error::{AppError, AppResult};
 pub use handlers::{
     Healthz, healthz_route, index_route, login_route, login_submit_route, logout_route,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,8 @@ use tracing_subscriber::{
 
 use comics::{
     APP_CSS, APP_JS, APPLE_TOUCH_ICON_PNG, AppState, AuthConfig, BCRYPT_COST, FAVICON_PNG,
-    FAVICON_SVG, VERSION, auth_middleware_fn, healthz_route, index_route, login_route,
-    login_submit_route, logout_route, rescan_books_route, scan_books, show_book_route,
+    FAVICON_SVG, VERSION, auth_middleware_fn, csrf_origin_guard, healthz_route, index_route,
+    login_route, login_submit_route, logout_route, rescan_books_route, scan_books, show_book_route,
     show_page_route, show_thumb_route, shuffle_book_route, shuffle_route,
 };
 
@@ -211,6 +211,12 @@ fn init_route(opts: &Opts) -> anyhow::Result<(Router, Arc<AppState>)> {
                 .make_span_with(DefaultMakeSpan::new().level(Level::DEBUG))
                 .on_response(DefaultOnResponse::new().level(Level::DEBUG)),
         )
+        // First-line CSRF defence: a stateless cross-site check on every
+        // unsafe-method request. Applied as a global outer layer so it also
+        // covers the public `/login` and `/logout` POSTs, which sit outside the
+        // auth layer. It is inert for safe methods, so every asset/image/
+        // `/healthz` GET passes untouched.
+        .layer(middleware::from_fn(csrf_origin_guard))
         .with_state(state.clone());
 
     Ok((router, state))
@@ -565,6 +571,54 @@ mod tests {
     async fn healthz() {
         let server = build_server().await;
         let res = server.get("/healthz").await;
+        assert_eq!(200, res.status_code());
+    }
+
+    /// The stateless CSRF origin guard rejects any state-changing POST a browser
+    /// reports as cross-site, including the public `/login` and `/logout` that
+    /// sit outside the auth layer. The guard is the outermost layer, so it fires
+    /// before auth and before the handler.
+    #[tokio::test]
+    async fn csrf_cross_site_post_is_forbidden() {
+        let server = build_server().await;
+        for path in ["/rescan", "/shuffle", "/login", "/logout"] {
+            let res = server
+                .post(path)
+                .add_header("sec-fetch-site", "cross-site")
+                .await;
+            assert_eq!(403, res.status_code(), "POST {path} cross-site");
+        }
+    }
+
+    /// A same-origin POST — the normal browser form submit — is untouched by the
+    /// guard and reaches the handler, whether flagged via `Sec-Fetch-Site` or a
+    /// matching `Origin`/`Host`.
+    #[tokio::test]
+    async fn csrf_same_origin_post_is_allowed() {
+        let server = build_server().await;
+
+        let res = server
+            .post("/shuffle")
+            .add_header("sec-fetch-site", "same-origin")
+            .await;
+        assert_eq!(303, res.status_code());
+
+        let res = server
+            .post("/shuffle")
+            .add_header("origin", "http://localhost")
+            .add_header("host", "localhost")
+            .await;
+        assert_eq!(303, res.status_code());
+    }
+
+    /// A GET is a safe method and never checked, even when reported cross-site.
+    #[tokio::test]
+    async fn csrf_safe_method_is_never_checked() {
+        let server = build_server().await;
+        let res = server
+            .get("/")
+            .add_header("sec-fetch-site", "cross-site")
+            .await;
         assert_eq!(200, res.status_code());
     }
 


### PR DESCRIPTION
## Summary

Adds a first-line CSRF defence: a stateless middleware that rejects state-changing requests a browser reports, or reveals, to be cross-site. Ported from `rdrs`'s `csrf_origin_guard` (only the header-only check — **not** the synchronizer token, which is unnecessary here and would be weaker since the session cookie value is a shared expiry timestamp, not a per-session secret).

## Why

`comics` uses ambient cookie auth, so it is technically in CSRF scope. `SameSite=Lax` on the session cookie already blocks forged cross-site POSTs to the auth-protected routes, but leaves the public `POST /login` / `POST /logout` (outside the auth layer) unguarded. This closes that gap as cheap, stateless defence-in-depth. Severity is LOW; this is discretionary hardening.

## How it works

- `Sec-Fetch-Site` is authoritative when present — only `cross-site` is rejected; `same-origin`/`same-site`/`none` pass.
- Falls back to comparing the `Origin` host against the request `Host`, ignoring scheme and port so it works behind a TLS-terminating reverse proxy without a configured public URL. `Origin: null` is rejected.
- Safe methods (GET/HEAD/OPTIONS/TRACE) and unclassifiable non-browser requests (no `Sec-Fetch-Site`, no `Origin` — e.g. `curl`, server-to-server) pass through, so no legitimate caller breaks.

Applied as a **global outer layer**, so it fires before auth and also covers the public `/login` and `/logout` POSTs. Inert for every safe-method GET (assets, images, `/healthz`).

## Changes

- New `src/csrf.rs`: `csrf_origin_guard` + helpers + 5 unit tests.
- `src/lib.rs`: export the guard.
- `src/main.rs`: wire `.layer(middleware::from_fn(csrf_origin_guard))` as the outermost layer + 3 integration tests.

No new dependencies, no secret/HMAC wiring, no template or JS change. `SameSite` stays `Lax`.

## Testing

- `cargo nextest run`: 76 passed (8 new; existing suite unchanged — its POSTs send no `Origin`/`Sec-Fetch-Site`, so they still pass).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo deny check`: all green.
- Manually verified with `curl`: cross-site POST → 403; same-origin / matching-Origin POST → 303; `Origin: null` → 403; header-less non-browser POST → 303; cross-site GET → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)