### PR TITLE
feat!: prefix configuration env vars with COMICS_

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,14 +24,14 @@ The lint config in `Cargo.toml` denies `unsafe_code` and `unexpected_cfgs` and t
 ### CLI subcommands
 
 - `cargo run -- list` (alias `ls`) — print books and page counts.
-- `cargo run -- hash-password` — prompt for a password and emit a bcrypt hash for `AUTH_PASSWORD_HASH`.
+- `cargo run -- hash-password` — prompt for a password and emit a bcrypt hash for `COMICS_AUTH_PASSWORD_HASH`.
 
 ## Architecture
 
 The crate is split into a thin binary (`src/main.rs`) and a library (`src/lib.rs`) so the test suite and integration tests can build routers directly.
 
 - **`main.rs`** — CLI parsing (`clap`), tracing setup, router assembly in `init_route`, graceful shutdown, and the `list` / `hash-password` subcommands. Embedded static assets (CSS/JS/icons) are served from here with immutable cache headers fingerprinted by `?v=<hash>`.
-- **`models/`** — the scan domain. `scan_books` walks the data dir in parallel (`rayon`), building `Book`s (each with a `cover`, sorted `pages`) into a `BookScan` that also holds `books_map` and `pages_map` (id → index/page) for O(1) lookups. IDs are `xxh3` hashes of the title/path salted with `seed` (`models/ids.rs`), so a fixed `SEED` yields stable URLs. **Scanning performs no image I/O** — `Page::new` only stats the path; dimensions are never read (a deliberate perf choice for slow disks).
+- **`models/`** — the scan domain. `scan_books` walks the data dir in parallel (`rayon`), building `Book`s (each with a `cover`, sorted `pages`) into a `BookScan` that also holds `books_map` and `pages_map` (id → index/page) for O(1) lookups. IDs are `xxh3` hashes of the title/path salted with `seed` (`models/ids.rs`), so a fixed `COMICS_SEED` yields stable URLs. **Scanning performs no image I/O** — `Page::new` only stats the path; dimensions are never read (a deliberate perf choice for slow disks).
 - **`handlers/`** — one module per route (`index`, `book`, `page`, `thumb`, `shuffle`, `rescan`, `login`, `health`). Handlers read shared state, never block the async runtime on CPU work without bounding it.
 - **`auth/`** — form-login authentication. `auth_middleware_fn` guards content routes; `config.rs` models credentials as `AuthConfig::{Some, None}`.
 - **`state.rs`** — `AppState` shared via `Arc`: the cookie signing `Key`, the `RwLock<Option<BookScan>>`, the thumbnail cache dir, and a `Semaphore` bounding concurrent thumbnail generation.
@@ -43,11 +43,11 @@ The initial scan runs on a background thread (`spawn_initial_scan`) *after* the 
 
 ### Authentication model
 
-Auth is enabled only when both `AUTH_USERNAME` and `AUTH_PASSWORD_HASH` are set; otherwise the server is fully public (and logs a warning). Login verifies the bcrypt hash once and issues a **signed session cookie** (`comics_session`) whose value is its own expiry timestamp (7-day TTL). The signing `Key` is generated at startup, so restarting invalidates all sessions. Every content route — including page images and thumbnails — sits behind the middleware; only `/login`, `/logout`, `/healthz`, and static assets are public. Unauthenticated `GET`s redirect to `/login?next=…` (the `next` target is validated to be same-site); other methods get `401`. The tests `auth_every_protected_route_rejects_anonymous` / `…reachable_when_logged_in` are the guardrails — keep them passing when touching routing.
+Auth is enabled only when both `COMICS_AUTH_USERNAME` and `COMICS_AUTH_PASSWORD_HASH` are set; otherwise the server is fully public (and logs a warning). Login verifies the bcrypt hash once and issues a **signed session cookie** (`comics_session`) whose value is its own expiry timestamp (7-day TTL). The signing `Key` is generated at startup, so restarting invalidates all sessions. Every content route — including page images and thumbnails — sits behind the middleware; only `/login`, `/logout`, `/healthz`, and static assets are public. Unauthenticated `GET`s redirect to `/login?next=…` (the `next` target is validated to be same-site); other methods get `401`. The tests `auth_every_protected_route_rejects_anonymous` / `…reachable_when_logged_in` are the guardrails — keep them passing when touching routing.
 
 ### Thumbnails
 
-`GET /thumb/{size}/{id}` serves on-demand JPEG thumbnails (`sm`=120px rail, `md`=400px covers; any other size → 404). Generation is disk-cached under `CACHE_DIR`, bounded by the `thumb_sem` semaphore, and runs in `spawn_blocking`. An undecodable source falls back to streaming the original bytes; cache writes are best-effort.
+`GET /thumb/{size}/{id}` serves on-demand JPEG thumbnails (`sm`=120px rail, `md`=400px covers; any other size → 404). Generation is disk-cached under `COMICS_CACHE_DIR`, bounded by the `thumb_sem` semaphore, and runs in `spawn_blocking`. An undecodable source falls back to streaming the original bytes; cache writes are best-effort.
 
 ## Versioning & Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,4 @@ Auth is enabled only when both `COMICS_AUTH_USERNAME` and `COMICS_AUTH_PASSWORD_
 - The Rust toolchain is pinned via `rust-toolchain.toml` (currently `1.96.0`); CI reads the channel from that file (no version is hard-coded in `ci.yml`). There is no separate MSRV — bumping the toolchain is a single edit to `rust-toolchain.toml`.
 - Test fixtures live in `fixtures/data/`; the two fixture books have stable IDs (with `seed=1`) hard-coded in tests.
 - User-facing strings in templates/login are Traditional Chinese (e.g. the login error `帳號或密碼錯誤`).
+- All configuration env vars carry a `COMICS_` prefix (`NO_COLOR` and the build-time `GIT_VERSION` are intentionally unprefixed). `main.rs` fails fast via `ensure_no_legacy_env_vars` if a pre-prefix name (`BIND`, `SEED`, …) is still set — keep the `LEGACY_ENV_VARS` list in sync when adding or renaming a `#[arg(env = …)]`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /out/comics /comics
 
-ENV BIND=0.0.0.0:8080
+ENV COMICS_BIND=0.0.0.0:8080
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 | `NO_COLOR` | Disable color output ([no-color.org](https://no-color.org/)) | _(off)_ |
 | `COMICS_SEED` | Seed to generate hashed IDs | _(random)_ |
 
+> **Migrating from an older release:** these variables were previously
+> unprefixed (`BIND`, `SEED`, `AUTH_USERNAME`, …). To catch stale configuration,
+> the server **refuses to start** if any of the old names is still set — rename
+> (or unset) them to their `COMICS_`-prefixed equivalents. `NO_COLOR` is
+> unchanged.
+
 ## Quick Start
 
 1. **Getting Started**:

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ While several options exist for self-hosted comic readers like [Calibre](https:/
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `AUTH_USERNAME` | Username for the login form | _(none)_ |
-| `AUTH_PASSWORD_HASH` | Hashed password for the login form | _(none)_ |
-| `BIND` | Bind host & port (defaults to loopback; the container image sets `0.0.0.0:8080` so a reverse proxy can reach it) | `127.0.0.1:8080` |
-| `DATA_DIR` | Data directory | `./data` |
-| `CACHE_DIR` | Directory for cached thumbnails | `comics-thumbs` under the system temp dir |
-| `LOG_FORMAT` | Log format (`full`, `compact`, `pretty`, `json`) | `full` |
+| `COMICS_AUTH_USERNAME` | Username for the login form | _(none)_ |
+| `COMICS_AUTH_PASSWORD_HASH` | Hashed password for the login form | _(none)_ |
+| `COMICS_BIND` | Bind host & port (defaults to loopback; the container image sets `0.0.0.0:8080` so a reverse proxy can reach it) | `127.0.0.1:8080` |
+| `COMICS_DATA_DIR` | Data directory | `./data` |
+| `COMICS_CACHE_DIR` | Directory for cached thumbnails | `comics-thumbs` under the system temp dir |
+| `COMICS_LOG_FORMAT` | Log format (`full`, `compact`, `pretty`, `json`) | `full` |
 | `NO_COLOR` | Disable color output ([no-color.org](https://no-color.org/)) | _(off)_ |
-| `SEED` | Seed to generate hashed IDs | _(random)_ |
+| `COMICS_SEED` | Seed to generate hashed IDs | _(random)_ |
 
 ## Quick Start
 

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -28,9 +28,9 @@ module.exports = defineConfig({
     timeout: 180_000,
     reuseExistingServer: !process.env.CI,
     env: {
-      AUTH_USERNAME: 'user',
-      AUTH_PASSWORD_HASH: TEST_PASSWORD_HASH,
-      SEED: '1',
+      COMICS_AUTH_USERNAME: 'user',
+      COMICS_AUTH_PASSWORD_HASH: TEST_PASSWORD_HASH,
+      COMICS_SEED: '1',
     },
   },
   projects: [

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,8 +318,43 @@ fn init_tracing(format: LogFormat) {
     tracing_subscriber::registry().with(layer).init();
 }
 
+/// Configuration environment variables that were renamed to carry the
+/// `COMICS_` prefix, paired with their new names. `NO_COLOR` (an ecosystem-wide
+/// convention) and `GIT_VERSION` (a build-time variable) were intentionally
+/// left unprefixed and are deliberately absent from this list.
+const LEGACY_ENV_VARS: [(&str, &str); 7] = [
+    ("AUTH_USERNAME", "COMICS_AUTH_USERNAME"),
+    ("AUTH_PASSWORD_HASH", "COMICS_AUTH_PASSWORD_HASH"),
+    ("BIND", "COMICS_BIND"),
+    ("DATA_DIR", "COMICS_DATA_DIR"),
+    ("CACHE_DIR", "COMICS_CACHE_DIR"),
+    ("LOG_FORMAT", "COMICS_LOG_FORMAT"),
+    ("SEED", "COMICS_SEED"),
+];
+
+/// Fail fast when a pre-prefix environment variable name is still set, so a
+/// stale deployment configuration surfaces immediately instead of being
+/// silently ignored (the old names are no longer wired to any option).
+fn ensure_no_legacy_env_vars() -> anyhow::Result<()> {
+    let found: Vec<String> = LEGACY_ENV_VARS
+        .iter()
+        .filter(|(old, _)| std::env::var_os(old).is_some())
+        .map(|(old, new)| format!("  {old} -> {new}"))
+        .collect();
+    if !found.is_empty() {
+        bail!(
+            "these environment variables were renamed with the COMICS_ prefix; \
+             rename (or unset) them to continue:\n{}",
+            found.join("\n")
+        );
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    ensure_no_legacy_env_vars()?;
+
     let opts = Opts::parse();
     debug!("Parsed options: {opts:?}");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,27 +68,32 @@ const PNG_HEADERS: AssetHeaders = [
 #[command(author, version=VERSION, about, long_about=None)]
 struct Opts {
     /// Username for the login form
-    #[arg(long, env = "AUTH_USERNAME")]
+    #[arg(long, env = "COMICS_AUTH_USERNAME")]
     auth_username: Option<String>,
     /// Hashed password for the login form
-    #[arg(long, env = "AUTH_PASSWORD_HASH")]
+    #[arg(long, env = "COMICS_AUTH_PASSWORD_HASH")]
     auth_password_hash: Option<String>,
     /// Bind host & port. Defaults to loopback so a bare-metal run is not
     /// exposed on all interfaces without opting in; the container image sets
-    /// `BIND=0.0.0.0:8080` so a reverse proxy can reach it.
-    #[arg(long, short = 'b', env = "BIND", default_value = "127.0.0.1:8080")]
+    /// `COMICS_BIND=0.0.0.0:8080` so a reverse proxy can reach it.
+    #[arg(
+        long,
+        short = 'b',
+        env = "COMICS_BIND",
+        default_value = "127.0.0.1:8080"
+    )]
     bind: String,
     /// Data directory
-    #[arg(long, env = "DATA_DIR", default_value = "./data")]
+    #[arg(long, env = "COMICS_DATA_DIR", default_value = "./data")]
     data_dir: PathBuf,
     /// Directory for cached thumbnails (defaults to a "comics-thumbs" dir under the system temp dir)
-    #[arg(long, env = "CACHE_DIR")]
+    #[arg(long, env = "COMICS_CACHE_DIR")]
     cache_dir: Option<PathBuf>,
     /// Log format
-    #[arg(long, env = "LOG_FORMAT", default_value = "full")]
+    #[arg(long, env = "COMICS_LOG_FORMAT", default_value = "full")]
     log_format: LogFormat,
     /// Seed to generate hashed IDs
-    #[arg(long, env = "SEED")]
+    #[arg(long, env = "COMICS_SEED")]
     seed: Option<u64>,
     #[command(subcommand)]
     command: Option<Commands>,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -39,6 +39,24 @@ fn initial_scan_finished() {
 }
 
 #[test]
+fn legacy_env_var_aborts_startup() {
+    // A stale, pre-prefix env var name must fail fast instead of being ignored.
+    // `env_clear` makes the check deterministic regardless of the ambient env.
+    Command::new(cmd::cargo_bin!("comics"))
+        .env_clear()
+        .env("BIND", "127.0.0.1:0")
+        .args(["--data-dir", "fixtures/data"])
+        .assert()
+        .failure()
+        .stdout_eq(str![])
+        .stderr_eq(str![[r"
+Error: these environment variables were renamed with the COMICS_ prefix; rename (or unset) them to continue:
+  BIND -> COMICS_BIND
+
+"]]);
+}
+
+#[test]
 fn initial_scan_failed() {
     let dir = tempdir().unwrap();
     let non_exist = dir.path().join("non_exist");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24,7 +24,7 @@ Pepper and Carrot 02 - Rainbow Potions (5P)
 fn initial_scan_finished() {
     Command::new(cmd::cargo_bin!("comics"))
         .env("NO_COLOR", "true")
-        .env("SEED", "0")
+        .env("COMICS_SEED", "0")
         .timeout(Duration::from_secs(1))
         .args(["--bind", "127.0.0.1:0", "--data-dir", "fixtures/data"])
         .assert()
@@ -45,7 +45,7 @@ fn initial_scan_failed() {
     let path = non_exist.to_string_lossy();
     Command::new(cmd::cargo_bin!("comics"))
         .env("NO_COLOR", "true")
-        .env("SEED", "0")
+        .env("COMICS_SEED", "0")
         .timeout(Duration::from_secs(1))
         .args(["--bind", "127.0.0.1:0", "--data-dir", &path])
         .assert()


### PR DESCRIPTION
## Summary

Renames all app runtime configuration environment variables to carry a `COMICS_` prefix, avoiding collisions with unrelated variables in shared deployment environments. Also adds a startup guard that fails fast when a stale, pre-prefix variable name is still set.

| Old | New |
| --- | --- |
| `AUTH_USERNAME` | `COMICS_AUTH_USERNAME` |
| `AUTH_PASSWORD_HASH` | `COMICS_AUTH_PASSWORD_HASH` |
| `BIND` | `COMICS_BIND` |
| `DATA_DIR` | `COMICS_DATA_DIR` |
| `CACHE_DIR` | `COMICS_CACHE_DIR` |
| `LOG_FORMAT` | `COMICS_LOG_FORMAT` |
| `SEED` | `COMICS_SEED` |

`NO_COLOR` (an ecosystem-wide convention, [no-color.org](https://no-color.org/)) and `GIT_VERSION` (a build-time version injection variable) are intentionally left **unprefixed**.

## Startup guard

Because the old names are no longer wired to any option, a leftover `BIND` / `SEED` / `AUTH_*` in a deployment would otherwise be silently ignored. `ensure_no_legacy_env_vars` in `main.rs` instead **aborts startup** and prints each stale name alongside its `COMICS_` replacement, so misconfiguration surfaces immediately. `NO_COLOR` and `GIT_VERSION` are excluded from the check.

```
Error: these environment variables were renamed with the COMICS_ prefix; rename (or unset) them to continue:
  BIND -> COMICS_BIND
```

## Changes

- `src/main.rs` — clap `#[arg(env = ...)]` names + `ensure_no_legacy_env_vars` guard
- `README.md` — configuration table + migration note
- `Dockerfile` — `ENV COMICS_BIND=0.0.0.0:8080`
- `e2e/playwright.config.js` — webServer env
- `tests/integration_test.rs` — `.env("COMICS_SEED", ...)` + `legacy_env_var_aborts_startup` test
- `CLAUDE.md` — doc references + convention note

Historical design docs under `docs/superpowers/` are point-in-time records and left untouched.

## Testing

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo nextest run` — 77 passed ✅

## ⚠️ Breaking Change

Existing deployments must rename these environment variables; the old unprefixed names are no longer recognized, and leaving one set now **prevents the server from starting**. Update your compose / k8s / CI secrets accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)