### PR TITLE
chore(deps): add rust-toolchain ecosystem, normalise dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,32 +1,41 @@
 version: 2
 updates:
-  - package-ecosystem: cargo
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
     cooldown:
       default-days: 7
     groups:
       cargo:
-        patterns: ["*"]
-  - package-ecosystem: docker
-    directory: /
+        patterns:
+          - "*"
+
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
     cooldown:
       default-days: 7
     groups:
       docker:
-        patterns: ["*"]
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    cooldown:
-      default-days: 7
-    groups:
-      actions:
-        patterns: ["*"]
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds a `rust-toolchain` ecosystem so Dependabot proposes compiler bumps for `rust-toolchain.toml` (currently pinned at `1.96.0`), on the same weekly schedule and 7-day cooldown as everything else. No group — there is only ever one entry.

Pinning the toolchain means nothing moves it by accident, which also means nothing moves it at all. This closes that gap.

## Also

Normalises the file to the shape now shared across the Rust repos:

- quoted scalars for `package-ecosystem` / `directory` / `interval`
- groups named after their ecosystem (`actions` → `github-actions`)
- fixed ecosystem order: `github-actions` → `cargo` → `rust-toolchain` → `docker`
- `patterns` expanded to block form
- drops `open-pull-requests-limit` (3 occurrences) — it never bound, since every ecosystem groups into a single PR

No change to `rust-toolchain.toml`, CI, or `Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)