### PR TITLE
ci: one run per ref at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@ name: CI
 
 on: [pull_request, push]
 
+# One run per ref at a time. A newer push supersedes the run it interrupted;
+# a tag does not — a tagged build publishes one specific version and nothing
+# should quietly cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,13 @@ on:
 
 name: Docker
 
+# One run per ref at a time. A newer push supersedes the run it interrupted;
+# a tag does not — a tagged build publishes one specific version and nothing
+# should quietly cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Merging two pull requests in quick succession starts two multi-arch image builds in parallel, both racing to push the same rolling tag. Whichever finishes last wins, which is not necessarily whichever commit is newest — an older build could overwrite a newer one.

`docker.yaml` had no concurrency group at all, and neither did `ci.yml`. Both get the same block:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
```

Superseding is right for a branch, where the rolling tag means "latest" by definition. It is wrong for a release: a tagged build publishes one specific version, and nothing should quietly cancel it — hence the condition rather than a flat `cancel-in-progress: true`.

`ci.yml` triggers on a bare `push`, which includes tags, so the exception is load-bearing there too, not just decoration for symmetry.

Part of a sweep applying the identical block across every repository that publishes an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)