### PR TITLE
ci: let latest follow metadata-action's latest=auto

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,7 +38,6 @@ jobs:
           tags: |
             type=raw,value=nightly,enable={{is_default_branch}}
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .


### PR DESCRIPTION
`type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}` moved `:latest` for *any* tag push. metadata-action already publishes `:latest` on its own through the default `flavor: latest=auto`, driven by the `type=semver` rule above it — so for an ordinary `v1.2.3` release the explicit rule was redundant.

Where the two disagree is a **pre-release**. `latest=auto` deliberately skips rc/beta/alpha tags:

> Pre-release (rc, beta, alpha) will only extend `{{version}}` (or `{{raw}}` if specified) as tag because they are updated frequently, and contain many breaking changes that are (by the author's design) not yet fit for public consumption.

The explicit rule overrode that, so a `v2.0.0-rc1` release would have pointed `:latest` at a release candidate. Dropping it restores the intended behaviour and matches every other project in the fleet, none of which sets `flavor` either.

### What changes

| tag pushed | before | after |
|---|---|---|
| `v1.2.3` | `1.2.3`, `latest` | `1.2.3`, `latest` — unchanged |
| `v2.0.0-rc1` | `2.0.0-rc1`, **`latest`** | `2.0.0-rc1` |
| non-semver (e.g. `backup-2026`) | **`latest`** | no tags — push step fails |

### The last row is worth a decision

This workflow triggers on `tags: ["*"]`. A tag that is not semver now produces no tags at all, so `docker/build-push-action` fails rather than silently republishing `:latest` from an arbitrary tag. I think failing loudly is the better of the two, but narrowing the trigger to `tags: ["v*"]` — which is what every other project here uses — would avoid the situation entirely. Left out of this PR deliberately; happy to follow up.

Separate from the rolling-tag (`:nightly` / `:main`) unification work, which does not touch this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)