### PR TITLE
fix(assets): drop the customized built-in behind the scan timestamp

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -519,6 +519,20 @@ mod tests {
         assert!(t.contains("Pepper and Carrot 02 - Rainbow Potions"));
     }
 
+    // The scan timestamp is localised client-side, but never through a
+    // customized built-in: WebKit does not implement `<time is="…">` (WebKit
+    // bug 182671), so that form is dead on Safari and app.js is one IIFE where
+    // a throw would cost the reader too. Opt in per element, so the sibling
+    // `<time>` holding an ISO duration is left alone.
+    #[tokio::test]
+    async fn index_opts_timestamps_into_client_side_localisation() {
+        let server = build_server().await;
+        let t = server.get("/").await.text();
+
+        assert!(!t.contains("is=\"x-time\""));
+        assert_eq!(1, t.matches("data-localtime").count());
+    }
+
     #[tokio::test]
     async fn get_book() {
         let book_id = DATA_IDS.first().unwrap();

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
             <div><b>{{ books.len() }}</b> volume(s)</div>
             <div>
               scanned
-              <time is="x-time" datetime="{{ scanned_at }}">{{ scanned_at }}</time>
+              <time data-localtime datetime="{{ scanned_at }}">{{ scanned_at }}</time>
               ·
               <time datetime="P{{ scan_duration / 1000.0 }}S">{{ scan_duration }}ms</time>
             </div>

--- a/vendor/assets/app.js
+++ b/vendor/assets/app.js
@@ -22,18 +22,19 @@
   if (themeBtn) themeBtn.addEventListener("click", toggleTheme);
 
   // ---- library: render server-side timestamps in the viewer's locale ----
-  if (window.customElements && !customElements.get("x-time")) {
-    class TimeComponent extends HTMLTimeElement {
-      connectedCallback() {
-        const d = new Date(this.getAttribute("datetime"));
-        this.innerHTML = new Intl.DateTimeFormat(undefined, {
-          dateStyle: "medium",
-          timeStyle: "medium",
-        }).format(d);
-      }
-    }
-    customElements.define("x-time", TimeComponent, { extends: "time" });
-  }
+  // Plain DOM rather than a customized built-in (`<time is="x-time">`): WebKit
+  // has declined to implement those (WebKit bug 182671), so the `extends` form
+  // of customElements.define is dead on Safari — and it lived in this file's
+  // single IIFE, where a throw would have taken the reader down with it.
+  // The server-rendered text is the fallback when this never runs.
+  document.querySelectorAll("time[data-localtime]").forEach(function (el) {
+    var d = new Date(el.getAttribute("datetime"));
+    if (Number.isNaN(d.getTime())) return; // keep whatever the server rendered
+    el.textContent = new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "medium",
+    }).format(d);
+  });
 
   // ---- reader ----
   if (!document.body.classList.contains("reader")) return;


### PR DESCRIPTION
## Problem

`templates/index.html` marked the scan timestamp with `<time is="x-time">`, a **customized built-in element** — the half of the custom-elements spec [WebKit has declined to implement](https://bugs.webkit.org/show_bug.cgi?id=182671). caniuse tracks Safari and iOS Safari as partial support for `custom-elementsv1` from their first supporting version through current, on exactly this note:

> Supports "Autonomous custom elements" but not "Customized built-in elements" see WebKit bug 182671.

Two consequences on Safari:

1. The timestamp never localises — it stays in the server's RFC 2822 form.
2. `app.js` is a single IIFE, and the `customElements.define(…, { extends: "time" })` call sat *above* the entire reader. A throw at that line would take paging, keyboard shortcuts, the thumbnail rail and scroll tracking down with it.

Note that (2) is the failure mode *if* `define` throws rather than silently ignoring the option; that specific behaviour was not observed first-hand here. (1) holds either way, and the fix removes the browser-dependent branch regardless.

Autonomous custom elements (`<my-element>`), Shadow DOM and the rest of Web Components are fine in Safari — only the `is=` form is affected.

## Change

Localise through plain DOM instead:

```js
document.querySelectorAll("time[data-localtime]").forEach(function (el) {
  var d = new Date(el.getAttribute("datetime"));
  if (Number.isNaN(d.getTime())) return; // keep whatever the server rendered
  el.textContent = new Intl.DateTimeFormat(undefined, { … }).format(d);
});
```

The marker is an opt-in `data-localtime` attribute rather than a bare `time[datetime]` selector, so the sibling `<time>` carrying the scan duration is left untouched. An unparseable value leaves the server-rendered text in place, keeping the progressive-enhancement behaviour the custom element had.

## Tests

`index_opts_timestamps_into_client_side_localisation` asserts the rendered index carries no `is="x-time"` and marks `data-localtime` exactly once — the count also guards against the duration `<time>` being opted in later.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo nextest run` (131 passed, 0 skipped) are clean locally.

## Out of scope

`templates/index.html:48` renders `datetime="P{{ … }}S"`, which is not a valid ISO 8601 duration — time components need the `T` prefix (`PT1.5S`). Semantic-markup only, no visible effect; left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)