### PR TITLE
fix(index): put the scan duration behind the T designator

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -533,6 +533,26 @@ mod tests {
         assert_eq!(1, t.matches("data-localtime").count());
     }
 
+    // A duration's time components sit behind the `T` designator, so a bare
+    // `P0.003S` parses as nothing at all — in ISO 8601 and in HTML's own
+    // duration-string grammar alike. The localised timestamp above carries
+    // `data-localtime`, so `<time datetime=` matches only the duration.
+    #[tokio::test]
+    async fn index_renders_the_scan_duration_as_a_valid_duration() {
+        let server = build_server().await;
+        let t = server.get("/").await.text();
+
+        let marker = "<time datetime=\"";
+        let start = t.find(marker).expect("a duration <time>") + marker.len();
+        let end = start + t[start..].find('"').expect("a closing quote");
+        let duration = &t[start..end];
+
+        assert!(
+            duration.starts_with("PT") && duration.ends_with('S'),
+            "not a valid duration string: {duration}"
+        );
+    }
+
     #[tokio::test]
     async fn get_book() {
         let book_id = DATA_IDS.first().unwrap();

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,7 +45,7 @@
               scanned
               <time data-localtime datetime="{{ scanned_at }}">{{ scanned_at }}</time>
               ·
-              <time datetime="P{{ scan_duration / 1000.0 }}S">{{ scan_duration }}ms</time>
+              <time datetime="PT{{ scan_duration / 1000.0 }}S">{{ scan_duration }}ms</time>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

The library page rendered the scan duration as `<time datetime="P0.003S">`.

A duration's time components sit behind the `T` designator, so that value is malformed in ISO 8601 and in HTML's own duration-string grammar alike — anything parsing the attribute (a browser extension, a crawler, an a11y tool) got nothing rather than a duration. The visible text was always correct; only the machine-readable attribute was wrong.

## Change

`templates/index.html` — `P{{ … }}S` → `PT{{ … }}S`.

## Test

`index_renders_the_scan_duration_as_a_valid_duration` pulls the value out of the rendered page and asserts it parses as `PT…S`. The sibling `<time>` on the line above carries `data-localtime`, so the `<time datetime=` marker matches only the duration.

Verified the test is not vacuous: reverting the template makes it fail with `not a valid duration string: P0S`.

`cargo clippy --all-targets -- -D warnings` clean, `cargo nextest run` → 132 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)