### PR TITLE
fix(auth): allow same-origin login behind proxies

### DIFF
--- a/src/csrf.rs
+++ b/src/csrf.rs
@@ -6,12 +6,13 @@
 //! request that is provably cross-site; anything it cannot classify is passed
 //! through, so it never breaks a legitimate caller:
 //!
-//! - **`Sec-Fetch-Site`** (sent by every current browser) is authoritative when
-//!   present. `same-origin`, `same-site`, and `none` (a direct navigation or a
-//!   user-typed URL) are allowed; only `cross-site` is rejected.
-//! - **`Origin`** is the fallback for the rare browser that omits
-//!   `Sec-Fetch-Site`. Its host is compared against the request's own `Host`;
-//!   a mismatch — or an opaque `Origin: null` — is rejected.
+//! - **`Sec-Fetch-Site`** (sent by every current browser) normally identifies
+//!   cross-site requests. A matching `Origin` and `Host` takes precedence,
+//!   since a reverse proxy may inject or overwrite fetch-metadata headers.
+//! - **`Origin`** is used to confirm same-origin requests or as the fallback
+//!   for the rare browser that omits `Sec-Fetch-Site`. Its host is compared
+//!   against the request's own `Host`; a mismatch — or an opaque `Origin: null`
+//!   — is rejected.
 //! - **Neither header** means a non-browser client (`curl`, a server-to-server
 //!   call). Those do not ride an ambient session cookie, so they are not
 //!   exposed to CSRF and are allowed through.
@@ -49,23 +50,30 @@ fn is_safe(method: &Method) -> bool {
 /// is passed through. See the module docs.
 fn is_cross_site(req: &Request) -> bool {
     let headers = req.headers();
+    let origin_is_same = origin_is_same(headers);
 
-    // `Sec-Fetch-Site` is authoritative where the browser sends it.
+    // A proxy can inject a stale or generic fetch-metadata value. A browser's
+    // `Origin` is more specific evidence when it matches the target host, so
+    // never reject that valid same-origin form submission.
     if let Some(site) = headers.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
-        return site.eq_ignore_ascii_case("cross-site");
+        return site.eq_ignore_ascii_case("cross-site") && origin_is_same != Some(true);
     }
 
+    origin_is_same.is_some_and(|same| !same)
+}
+
+fn origin_is_same(headers: &http::HeaderMap) -> Option<bool> {
     let Some(origin) = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok()) else {
         // No Sec-Fetch-Site and no Origin → a non-browser client.
-        return false;
+        return None;
     };
     // `Origin: null` is opaque (a sandboxed iframe, a cross-origin redirect) and
     // never legitimate for a state-changing request here.
     if origin.eq_ignore_ascii_case("null") {
-        return true;
+        return Some(false);
     }
     let Some(origin_host) = host_of(origin) else {
-        return true;
+        return Some(false);
     };
     let request_host = headers
         .get(header::HOST)
@@ -73,7 +81,7 @@ fn is_cross_site(req: &Request) -> bool {
         .map(strip_port);
     // A missing/garbled Host with a present Origin cannot be confirmed
     // same-origin, so treat it as cross-site.
-    request_host != Some(origin_host)
+    Some(request_host == Some(origin_host))
 }
 
 /// The host of an `Origin` value (`scheme://host[:port]`), lower-cased and with
@@ -119,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn sec_fetch_site_is_authoritative() {
+    fn sec_fetch_site_rejects_cross_site_requests() {
         for allowed in ["same-origin", "same-site", "none", "SAME-ORIGIN"] {
             assert!(
                 !is_cross_site(&req(Method::POST, &[("sec-fetch-site", allowed)])),
@@ -130,8 +138,21 @@ mod tests {
             Method::POST,
             &[("sec-fetch-site", "cross-site")]
         )));
-        // It wins over a same-looking Origin/Host, in both directions.
+        // A mismatched Origin remains cross-site even when a proxy supplies
+        // fetch metadata.
         assert!(is_cross_site(&req(
+            Method::POST,
+            &[
+                ("sec-fetch-site", "cross-site"),
+                ("origin", "https://evil.example.com"),
+                ("host", "app.example.com"),
+            ]
+        )));
+    }
+
+    #[test]
+    fn matching_origin_overrides_a_proxy_injected_cross_site_header() {
+        assert!(!is_cross_site(&req(
             Method::POST,
             &[
                 ("sec-fetch-site", "cross-site"),

--- a/src/csrf.rs
+++ b/src/csrf.rs
@@ -28,6 +28,17 @@
 //! proxy that strips `Origin` outright: there is nothing left to confirm with,
 //! and an injected `cross-site` label then still wins.
 //!
+//! That last point has a sharper edge, and it is the one prerequisite this
+//! relaxation carries: **a proxy in front must leave `Origin` alone.** A
+//! configuration that rewrites it to the backend host — `proxy_set_header
+//! Origin $host`, the usual way to talk a backend's own origin check into
+//! accepting a WebSocket upgrade — makes `Origin` match unconditionally, and
+//! this guard then accepts every request. That is strictly worse than the
+//! `Sec-Fetch-Site`-only rule it replaces, which would have gone on rejecting a
+//! genuine cross-site POST. The session cookie's `SameSite=Strict` is what
+//! stops such a deployment from being exploitable; this layer is defence in
+//! depth and must not be the one anything relies on.
+//!
 //! Scheme and port are deliberately ignored in the `Origin`/`Host` comparison:
 //! behind a TLS-terminating reverse proxy the browser's `Origin` is `https://`
 //! while the forwarded `Host` carries no scheme, and the proxy commonly strips

--- a/src/csrf.rs
+++ b/src/csrf.rs
@@ -17,6 +17,17 @@
 //!   call). Those do not ride an ambient session cookie, so they are not
 //!   exposed to CSRF and are allowed through.
 //!
+//! Letting `Origin` overrule a `cross-site` label is a deliberate relaxation:
+//! `Sec-Fetch-Site` is no longer an unappealable verdict. It costs nothing an
+//! attacker can spend, because both headers are set by the browser and neither
+//! is reachable from script. For the two hosts to match, the attacking page
+//! would have to be served from the target host — at which point it is
+//! same-origin and this is not CSRF. The one way a cross-site request arrives
+//! carrying the target's own `Origin` is a redirect chain, and the browser
+//! taints that to `null`, which is still rejected. What is *not* covered is a
+//! proxy that strips `Origin` outright: there is nothing left to confirm with,
+//! and an injected `cross-site` label then still wins.
+//!
 //! Scheme and port are deliberately ignored in the `Origin`/`Host` comparison:
 //! behind a TLS-terminating reverse proxy the browser's `Origin` is `https://`
 //! while the forwarded `Host` carries no scheme, and the proxy commonly strips
@@ -50,23 +61,27 @@ fn is_safe(method: &Method) -> bool {
 /// is passed through. See the module docs.
 fn is_cross_site(req: &Request) -> bool {
     let headers = req.headers();
-    let origin_is_same = origin_is_same(headers);
 
     // A proxy can inject a stale or generic fetch-metadata value. A browser's
     // `Origin` is more specific evidence when it matches the target host, so
-    // never reject that valid same-origin form submission.
+    // never reject that valid same-origin form submission. `&&` short-circuits,
+    // so the comparison only runs for the requests that would be rejected.
     if let Some(site) = headers.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
-        return site.eq_ignore_ascii_case("cross-site") && origin_is_same != Some(true);
+        return site.eq_ignore_ascii_case("cross-site") && origin_is_same(headers) != Some(true);
     }
 
-    origin_is_same.is_some_and(|same| !same)
+    // No `Sec-Fetch-Site` at all: `None` here means no `Origin` either, which
+    // makes this a non-browser client — see the module docs.
+    origin_is_same(headers).is_some_and(|same| !same)
 }
 
+/// Whether the request's `Origin` names the same host as its `Host`.
+///
+/// `None` means there is no `Origin` to judge by; the caller decides what that
+/// absence implies. `Some(false)` covers every `Origin` that cannot be
+/// confirmed to match, including an opaque or unparseable one.
 fn origin_is_same(headers: &http::HeaderMap) -> Option<bool> {
-    let Some(origin) = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok()) else {
-        // No Sec-Fetch-Site and no Origin → a non-browser client.
-        return None;
-    };
+    let origin = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok())?;
     // `Origin: null` is opaque (a sandboxed iframe, a cross-origin redirect) and
     // never legitimate for a state-changing request here.
     if origin.eq_ignore_ascii_case("null") {
@@ -157,6 +172,38 @@ mod tests {
             &[
                 ("sec-fetch-site", "cross-site"),
                 ("origin", "https://app.example.com"),
+                ("host", "app.example.com"),
+            ]
+        )));
+    }
+
+    /// The `Origin` override only rescues a request whose origin is *confirmed*
+    /// same-host. Anything short of that leaves the `cross-site` label standing.
+    #[test]
+    fn an_unconfirmable_origin_does_not_override_the_cross_site_header() {
+        // A cross-origin redirect chain: the browser taints Origin to null.
+        assert!(is_cross_site(&req(
+            Method::POST,
+            &[
+                ("sec-fetch-site", "cross-site"),
+                ("origin", "null"),
+                ("host", "app.example.com"),
+            ]
+        )));
+        // No Host to compare against.
+        assert!(is_cross_site(&req(
+            Method::POST,
+            &[
+                ("sec-fetch-site", "cross-site"),
+                ("origin", "https://app.example.com"),
+            ]
+        )));
+        // An Origin with no `://` authority cannot be parsed into a host.
+        assert!(is_cross_site(&req(
+            Method::POST,
+            &[
+                ("sec-fetch-site", "cross-site"),
+                ("origin", "app.example.com"),
                 ("host", "app.example.com"),
             ]
         )));


### PR DESCRIPTION
## Summary
- accept same-origin requests when a reverse proxy incorrectly injects `Sec-Fetch-Site: cross-site`
- retain CSRF rejection for requests with a mismatched Origin and Host
- add regression coverage for the proxy-header scenario

## Testing
- cargo fmt --check
- cargo nextest run