### PR TITLE
feat(csrf): add an escape hatch for plain-HTTP LAN lockouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Thin binary (`src/main.rs`) + library (`src/lib.rs`), so tests can build routers
 | `models/` | `scan_books` (parallel via `rayon`) → `BookScan` with `books_map` / `pages_map` for O(1) lookup; IDs are `xxh3(seed, …)` (`ids.rs`) |
 | `handlers/` | One module per route: `index`, `book`, `page`, `thumb`, `shuffle`, `rescan`, `login`, `health` |
 | `auth/` | `config`, `session`, `middleware`, `ratelimit`, `trusted_proxies`, `audit` |
-| `csrf.rs` | Stateless `Sec-Fetch-Site`/`Origin` check on unsafe methods; global outer layer |
+| `csrf.rs` | Stateless `Sec-Fetch-Site`/`Origin` check on unsafe methods; global outer layer, omitted entirely under `COMICS_DISABLE_CSRF_GUARD` |
 | `security_headers.rs` | `security_headers_layer` (global: CSP, `nosniff`, `X-Frame-Options`, `Referrer-Policy`, `Cross-Origin-*`, `Permissions-Policy`, plus HSTS when `COMICS_HSTS_MAX_AGE` is set), `no_store_html` (inside auth) |
 | `secret.rs` | `Secret` → `session_key()` (SHA-512) and `id_seed()` (SHA-256), each domain-separated |
 | `state.rs` | `AppState`: signing `Key`, `RwLock<Option<BookScan>>`, cache dir, thumbnail `Semaphore` |
@@ -51,7 +51,7 @@ Protected: `GET /`, `GET /book/{id}`, `GET /data/{id}` (page image), `GET /thumb
 
 Public: `GET|POST /login`, `POST /logout`, `GET /healthz`, and the static assets (`/assets/app.css`, `/assets/app.js`, `/assets/theme.js`, `/favicon.svg`, `/favicon-32.png`, `/apple-touch-icon.png`).
 
-Layers, outermost first: `security_headers_layer` → `csrf_origin_guard` → `TraceLayer` → *(protected only)* `auth_middleware_fn` → `no_store_html`.
+Layers, outermost first: `security_headers_layer` → `csrf_origin_guard` → `TraceLayer` → *(protected only)* `auth_middleware_fn` → `no_store_html`. `COMICS_DISABLE_CSRF_GUARD` drops `csrf_origin_guard` out of that chain — it is an escape hatch for plain-HTTP LAN hosts that get no `Sec-Fetch-Site` and an opaque `Origin: null`, which otherwise locks the operator out of the login form. See the `csrf.rs` module docs before touching it.
 
 ### Content-Security-Policy
 
@@ -87,5 +87,5 @@ Enabled only when both `COMICS_AUTH_USERNAME` and `COMICS_AUTH_PASSWORD_HASH` ar
 - The toolchain is pinned in `rust-toolchain.toml` (currently `1.97.1`); CI reads the channel from that file. There is no separate MSRV.
 - Test fixtures live in `fixtures/data/`; the two fixture books have stable IDs (derived from `TEST_SECRET` in `main.rs`) hard-coded in tests as `DATA_IDS`. Changing the secret or the derivation means recomputing them — run the binary with that secret against `fixtures/data` and read the `/book/…` hrefs off the index page.
 - User-facing strings in templates/login are Traditional Chinese (e.g. the login error `帳號或密碼錯誤`).
-- Config env vars all carry a `COMICS_` prefix (`NO_COLOR` and build-time `GIT_VERSION` excepted): `BIND`, `DATA_DIR`, `CACHE_DIR`, `LOG_FORMAT`, `SECRET`, `AUTH_USERNAME`, `AUTH_PASSWORD_HASH`, `COOKIE_SECURE`, `HSTS_MAX_AGE`, `TRUSTED_PROXIES`.
+- Config env vars all carry a `COMICS_` prefix (`NO_COLOR` and build-time `GIT_VERSION` excepted): `BIND`, `DATA_DIR`, `CACHE_DIR`, `LOG_FORMAT`, `SECRET`, `AUTH_USERNAME`, `AUTH_PASSWORD_HASH`, `COOKIE_SECURE`, `HSTS_MAX_AGE`, `TRUSTED_PROXIES`, `DISABLE_CSRF_GUARD`.
 - `ensure_no_legacy_env_vars` fails fast on retired names. Keep `LEGACY_ENV_VARS` in sync when adding, renaming or removing a `#[arg(env = …)]` — a silently-ignored variable is worse than a startup failure, because the fallback (a random secret) looks like it works.

--- a/src/csrf.rs
+++ b/src/csrf.rs
@@ -21,6 +21,25 @@
 //! while the forwarded `Host` carries no scheme, and the proxy commonly strips
 //! the port. Matching on host alone is what keeps the check working in that
 //! standard deployment without a configured public URL.
+//!
+//! # The plain-HTTP LAN hole, and the escape hatch
+//!
+//! Fetch metadata is only sent to *potentially trustworthy* origins — HTTPS, or
+//! `localhost`. A plain-HTTP LAN host such as `http://nas.local` is neither, so
+//! **no `Sec-Fetch-Site` ever arrives** and every request falls through to the
+//! `Origin` branch. That is survivable until a browser reports an opaque
+//! `Origin: null` (a sandboxed iframe, or a privacy setting that suppresses the
+//! header): the login `POST` is then rejected, and because the operator cannot
+//! log in, there is no way back from inside the app.
+//!
+//! `--disable-csrf-guard` / `COMICS_DISABLE_CSRF_GUARD` exists for exactly that
+//! dead end — it removes this layer from the router altogether. Reaching the
+//! server over HTTPS or through a `localhost` tunnel restores `Sec-Fetch-Site`
+//! and fixes the same lockout while giving nothing up, so it is the better
+//! answer wherever it is available. What survives the escape hatch is the
+//! session cookie's `SameSite=Strict`, which is what actually stops a
+//! cross-site `POST` from carrying credentials; this module is defence in depth
+//! layered on that, never the only lock.
 
 use axum::{
     extract::Request,

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,28 @@ struct Opts {
     /// single bucket.
     #[arg(long, env = "COMICS_TRUSTED_PROXIES")]
     trusted_proxies: Option<TrustedProxies>,
+    /// Turn off the CSRF origin guard entirely. Off by default, and there is no
+    /// good reason to set it on a deployment reachable from anywhere untrusted.
+    ///
+    /// It exists for one shape the guard cannot serve: a plain-HTTP LAN host
+    /// (`http://nas.local`). Fetch-metadata headers are only sent to
+    /// potentially-trustworthy origins — HTTPS or `localhost` — so no
+    /// `Sec-Fetch-Site` ever arrives, the guard falls back to `Origin`, and a
+    /// browser that reports an opaque `Origin: null` then locks the operator out
+    /// of the login form with no way back. Serving over HTTPS fixes the same
+    /// problem without giving anything up; prefer that when it is available.
+    ///
+    /// What is left when this is set: the session cookie's `SameSite=Strict`,
+    /// which is what actually keeps a cross-site POST from carrying credentials.
+    /// This guard is defence in depth on top of it, not the only lock.
+    #[arg(
+        long,
+        env = "COMICS_DISABLE_CSRF_GUARD",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value = "false"
+    )]
+    disable_csrf_guard: bool,
     /// Bind host & port. Defaults to loopback so a bare-metal run is not
     /// exposed on all interfaces without opting in; the container image sets
     /// `COMICS_BIND=0.0.0.0:8080` so a reverse proxy can reach it.
@@ -270,11 +292,26 @@ fn init_route(opts: &Opts) -> (Router, Arc<AppState>) {
             TraceLayer::new_for_http()
                 .make_span_with(DefaultMakeSpan::new().level(Level::DEBUG))
                 .on_response(DefaultOnResponse::new().level(Level::DEBUG)),
-        )
-        // Global outer layer so the check also covers the public `/login` and
-        // `/logout` POSTs, which sit outside the auth layer; inert for safe
-        // methods, so every asset/image/`/healthz` GET passes untouched.
-        .layer(middleware::from_fn(csrf_origin_guard))
+        );
+
+    // Global outer layer so the check also covers the public `/login` and
+    // `/logout` POSTs, which sit outside the auth layer; inert for safe
+    // methods, so every asset/image/`/healthz` GET passes untouched. Skipped
+    // entirely rather than made permissive when disabled, so the disabled build
+    // has no classification logic left to get wrong.
+    let router = if opts.disable_csrf_guard {
+        warn!(
+            "CSRF origin guard disabled by --disable-csrf-guard; every \
+             state-changing request is accepted whatever its origin. The \
+             session cookie's SameSite=Strict is the only cross-site defence \
+             left. Serving over HTTPS is the way to undo this."
+        );
+        router
+    } else {
+        router.layer(middleware::from_fn(csrf_origin_guard))
+    };
+
+    let router = router
         // Global outer layer so the policy also covers `/login`, `/healthz` and
         // the assets. Everything but HSTS is unconditional; HSTS stays inert
         // unless a max-age is configured.
@@ -504,10 +541,16 @@ mod tests {
     }
 
     async fn build_server_at(data_dir: &str) -> TestServer {
+        build_server_with(data_dir, &[]).await
+    }
+
+    async fn build_server_with(data_dir: &str, extra_args: &[&str]) -> TestServer {
         use std::{thread, time};
 
         let (tx, _) = oneshot::channel::<()>();
-        let mut opts = Opts::parse_from(["comics", "--data-dir", data_dir]);
+        let mut args = vec!["comics", "--data-dir", data_dir];
+        args.extend_from_slice(extra_args);
+        let mut opts = Opts::parse_from(args);
         // Only when the caller did not pass `--secret` itself.
         opts.secret
             .get_or_insert_with(|| TEST_SECRET.parse().unwrap());
@@ -778,6 +821,40 @@ mod tests {
             .post("/shuffle")
             .add_header("origin", "http://localhost")
             .add_header("host", "localhost")
+            .await;
+        assert_eq!(303, res.status_code());
+    }
+
+    /// The plain-HTTP LAN lockout the escape hatch exists for: no
+    /// `Sec-Fetch-Site` (the origin is not potentially trustworthy, so the
+    /// browser sends none) plus an opaque `Origin: null` is rejected by default.
+    #[tokio::test]
+    async fn csrf_null_origin_post_is_forbidden_by_default() {
+        let server = build_server().await;
+        let res = server
+            .post("/shuffle")
+            .add_header("origin", "null")
+            .add_header("host", "nas.local")
+            .await;
+        assert_eq!(403, res.status_code());
+    }
+
+    /// With the guard disabled the same request reaches the handler. The layer
+    /// is not installed at all, so this also covers the `cross-site` label.
+    #[tokio::test]
+    async fn csrf_guard_can_be_disabled() {
+        let server = build_server_with("./fixtures/data", &["--disable-csrf-guard"]).await;
+
+        let res = server
+            .post("/shuffle")
+            .add_header("origin", "null")
+            .add_header("host", "nas.local")
+            .await;
+        assert_eq!(303, res.status_code());
+
+        let res = server
+            .post("/shuffle")
+            .add_header("sec-fetch-site", "cross-site")
             .await;
         assert_eq!(303, res.status_code());
     }


### PR DESCRIPTION
## Problem

Fetch metadata headers are only sent to *potentially trustworthy* origins — HTTPS, or `localhost`. A plain-HTTP LAN host such as `http://nas.local` is neither, so **no `Sec-Fetch-Site` ever arrives** and every unsafe request falls through to the `Origin` branch of the guard.

That is survivable until the browser reports an opaque `Origin: null` — a sandboxed iframe, or a privacy setting that suppresses the header. The login `POST` is then rejected with a bare `403`, and because the operator cannot log in, there is no way back from inside the app. Observed on Firefox 153 against an mDNS `.local` host over plain HTTP.

## Change

`--disable-csrf-guard` / `COMICS_DISABLE_CSRF_GUARD` (default `false`) **removes the layer from the router entirely** rather than making it permissive, so the disabled build has no classification logic left to get wrong. Startup logs a WARN naming exactly what is given up.

What survives the escape hatch is the session cookie's `SameSite=Strict`, which is what actually stops a cross-site `POST` from carrying credentials — this guard is defence in depth layered on that, never the only lock.

HTTPS or a `localhost` tunnel restores `Sec-Fetch-Site` and fixes the same lockout while giving nothing up, so both the module docs and the flag's help text point there first.

Note the flag accepts only `true`/`false`, not `1` — same clap bool parser as the existing `COMICS_COOKIE_SECURE`.

## Testing

- `cargo nextest run` — 184 passed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check`
- New: `csrf_null_origin_post_is_forbidden_by_default`, `csrf_guard_can_be_disabled`
- Verified against a live binary with the reported header shape (`Origin: null`, `Host: abc.local`): guard on → `403`, guard off → `303`

🤖 Generated with [Claude Code](https://claude.com/claude-code)