### PR TITLE
fix(auth): close the login timing oracle and stop truncating passwords

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ The initial scan runs on a background thread (`spawn_initial_scan`) *after* the 
 
 Enabled only when both `COMICS_AUTH_USERNAME` and `COMICS_AUTH_PASSWORD_HASH` are set; otherwise the server is fully public (and logs a warning). Unauthenticated `GET`s redirect to `/login?next=…` (constrained by `safe_next`); other methods get `401`.
 
+- `verify_credentials` deliberately does **not** short-circuit: the bcrypt verification runs even when the username is wrong, and the username is compared with `subtle::ConstantTimeEq`, so response time cannot enumerate it. Restoring the obvious `username == expected && bcrypt::verify(…)` reintroduces a ~5-orders-of-magnitude timing oracle. Passwords over `MAX_PASSWORD_BYTES` (72, bcrypt's ceiling) are refused rather than silently truncated — in both `verify_credentials` and the `hash-password` subcommand.
 - Sessions live in the in-memory `SessionStore`; the cookie carries an opaque 128-bit identifier and nothing else. **Sessions do not survive a restart** — that is deliberate, and it is what makes logout enforceable.
 - `POST /logout` ends **every** live session, not just the caller's — comics has one set of credentials, so they are all the same person's, and this is the only way to invalidate a stolen cookie short of a restart. The route is public, so store membership is what authorises the clear (`SessionStore::destroy_all`).
 - Cookie: `HttpOnly`, `SameSite=Strict`, `Path=/`; `Secure` + renamed `__Host-comics_session` only when `COMICS_COOKIE_SECURE` is set. Exactly one name is accepted.
@@ -72,7 +73,7 @@ Enabled only when both `COMICS_AUTH_USERNAME` and `COMICS_AUTH_PASSWORD_HASH` ar
 - `POST /login` is rate-limited to 5 attempts per client IP per 60 s (`auth/ratelimit.rs`). The key is the TCP peer unless `COMICS_TRUSTED_PROXIES` lists it — **empty by default**, so `X-Forwarded-For` is ignored out of the box.
 - Audit events (`auth/audit.rs`) are INFO/WARN, so the default `error,comics=info` filter shows them; pair with `--log-format json`. Session identifiers are never logged in cleartext.
 
-`auth_every_protected_route_rejects_anonymous` / `…reachable_when_logged_in` are the guardrails — keep them passing when touching routing. `removal_cookie_mirrors_the_session_cookie` keeps logout's removal cookie in step with the issued one.
+`auth_every_protected_route_rejects_anonymous` / `…reachable_when_logged_in` are the guardrails — keep them passing when touching routing. `removal_cookie_mirrors_the_session_cookie` keeps logout's removal cookie in step with the issued one. `wrong_username_costs_what_a_wrong_password_costs` and `a_password_at_the_limit_does_not_accept_its_own_suffixes` guard the two properties above.
 
 ### Thumbnails
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "serde",
  "sha2 0.11.0",
  "snapbox",
+ "subtle",
  "tempfile",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 # Used to salt-and-hash session identifiers before they reach the audit log;
 # `xxhash-rust` is not a cryptographic hash and would not do.
 sha2 = "0.11.0"
+# Already in the tree as a transitive dependency of `bcrypt`, which uses it to
+# compare hashes. Used here to compare the *username* without an early exit, so
+# that a wrong username cannot be told from a wrong password by response time.
+subtle = "2.6.1"
 tokio = { version = "1.52.3", features = [
   "fs",
   "macros",

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ Confirmation:
 $2a$10$...Ot6
 ```
 
+bcrypt hashes at most **72 bytes**, so a longer password is refused here rather
+than quietly hashed with its tail discarded. Bytes, not characters: a
+Traditional Chinese passphrase costs three bytes per character and so reaches the
+limit at 24 of them.
+
 ### `list` (alias: `ls`)
 
 List all books and their page counts:

--- a/src/handlers/login.rs
+++ b/src/handlers/login.rs
@@ -9,15 +9,16 @@ use axum::{
 use cookie::CookieJar;
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header};
 use serde::Deserialize;
+use subtle::{Choice, ConstantTimeEq as _};
 use tracing::{error, info, warn};
 
-use crate::VERSION;
 use crate::assets::assets_version;
 use crate::auth::{
     AuthConfig, AuthState, authenticate, build_session_cookie, build_session_removal_cookie,
     rate_limit_key, session_id_of, user_agent,
 };
 use crate::state::AppState;
+use crate::{MAX_PASSWORD_BYTES, VERSION};
 
 #[derive(Template)]
 #[template(path = "login.html")]
@@ -48,13 +49,41 @@ pub struct LoginForm {
 
 /// Check submitted credentials against the configured ones. When no credentials
 /// are configured every request is already public, so anything is accepted.
+///
+/// **Both halves always run.** The obvious spelling — `username == expected &&
+/// bcrypt::verify(…)` — short-circuits, so a wrong username answers in
+/// microseconds while a wrong password pays for a `BCRYPT_COST` verification
+/// (~100 ms). The response is byte-identical either way, but the *timing* is not,
+/// and that discrepancy is enough to enumerate the username: exactly the "quick
+/// exit" pattern the OWASP Authentication Cheat Sheet warns against under
+/// *Authentication and Error Messages*. So the verification is computed
+/// unconditionally and combined with a bitwise `&` on [`Choice`], which — unlike
+/// `&&` — is not a control-flow branch.
+///
+/// The username comparison is [`ConstantTimeEq`] for the same reason at a
+/// smaller scale; it still reveals whether the lengths match, which is inherent
+/// to comparing at all and says nothing an attacker can act on.
 pub fn verify_credentials(auth: &AuthConfig, username: &str, password: &str) -> bool {
     match auth {
         AuthConfig::None => true,
         AuthConfig::Some {
             username: expected_user,
             password_hash,
-        } => username == expected_user && bcrypt::verify(password, password_hash).unwrap_or(false),
+        } => {
+            // Refuse before hashing what bcrypt would only truncate. This exit
+            // *is* a branch, but it turns on the length of the attacker's own
+            // submission and so tells them nothing they did not already know —
+            // and it is what keeps an oversized body from buying a verification.
+            // See `hash_password` in `main.rs` for the other half.
+            if password.len() > MAX_PASSWORD_BYTES {
+                return false;
+            }
+            let username_ok = username.as_bytes().ct_eq(expected_user.as_bytes());
+            let password_ok = Choice::from(u8::from(
+                bcrypt::verify(password, password_hash).unwrap_or(false),
+            ));
+            (username_ok & password_ok).into()
+        }
     }
 }
 
@@ -282,7 +311,7 @@ pub async fn logout_route(
 mod tests {
     use super::*;
     use parking_lot::{Mutex, RwLock};
-    use std::path::PathBuf;
+    use std::{path::PathBuf, time::Instant};
 
     fn some_auth() -> AuthConfig {
         AuthConfig::Some {
@@ -436,6 +465,75 @@ mod tests {
     #[test]
     fn verify_credentials_public_when_unconfigured() {
         assert!(verify_credentials(&AuthConfig::None, "", ""));
+    }
+
+    /// Regression: the check was `username == expected && bcrypt::verify(…)`,
+    /// which short-circuits — so a wrong username answered in microseconds while
+    /// a wrong password paid for a whole verification. The bodies were identical,
+    /// but the response *time* enumerated the username anyway.
+    ///
+    /// Cost 8 puts a verification four orders of magnitude above the string
+    /// comparison a short circuit would leave, so the ratio has room to spare and
+    /// does not need a quiet machine. `[profile.dev.package."*"]` optimises
+    /// bcrypt even in a debug build, which keeps this under a few tens of
+    /// milliseconds.
+    #[test]
+    fn wrong_username_costs_what_a_wrong_password_costs() {
+        let auth = AuthConfig::Some {
+            username: "alice".to_string(),
+            password_hash: bcrypt::hash("s3cret", 8).unwrap(),
+        };
+
+        let started = Instant::now();
+        assert!(!verify_credentials(&auth, "alice", "nope"));
+        let wrong_password = started.elapsed();
+
+        let started = Instant::now();
+        assert!(!verify_credentials(&auth, "mallory", "nope"));
+        let wrong_username = started.elapsed();
+
+        assert!(
+            wrong_username * 4 >= wrong_password,
+            "a wrong username took {wrong_username:?} against {wrong_password:?} \
+             for a wrong password — the credential check is short-circuiting"
+        );
+    }
+
+    /// Regression: bcrypt reads only the first [`MAX_PASSWORD_BYTES`] and the
+    /// crate truncates rather than erroring, so every string sharing that prefix
+    /// verified against the same hash — the password plus any suffix at all was
+    /// accepted. Refusing over-long input is what closes that.
+    #[test]
+    fn a_password_at_the_limit_does_not_accept_its_own_suffixes() {
+        let password = "x".repeat(MAX_PASSWORD_BYTES);
+        let auth = AuthConfig::Some {
+            username: "alice".to_string(),
+            password_hash: bcrypt::hash(&password, 4).unwrap(),
+        };
+        assert!(verify_credentials(&auth, "alice", &password));
+        assert!(!verify_credentials(
+            &auth,
+            "alice",
+            &format!("{password}extra")
+        ));
+    }
+
+    /// A Traditional Chinese passphrase is three bytes per character, which is
+    /// where this limit is met soonest — 24 characters, not 72.
+    #[test]
+    fn the_password_limit_is_counted_in_bytes_not_characters() {
+        let password = "密".repeat(24);
+        assert_eq!(MAX_PASSWORD_BYTES, password.len());
+        let auth = AuthConfig::Some {
+            username: "alice".to_string(),
+            password_hash: bcrypt::hash(&password, 4).unwrap(),
+        };
+        assert!(verify_credentials(&auth, "alice", &password));
+        assert!(!verify_credentials(
+            &auth,
+            "alice",
+            &format!("{password}密")
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,22 @@ pub use state::AppState;
 
 pub const VERSION: &str = env!("APP_VERSION");
 pub const BCRYPT_COST: u32 = 11u32;
+
+/// Bytes of a password bcrypt actually hashes.
+///
+/// The algorithm reads no further, and the `bcrypt` crate's `hash`/`verify`
+/// *silently* drop the rest rather than erroring — so without a check of our own
+/// a 100-character passphrase would be its first 72 bytes wearing a disguise,
+/// and the operator would never be told. The OWASP Authentication Cheat Sheet
+/// asks for the opposite ("Do not silently truncate passwords") and for a
+/// maximum input length on the comparison function; this constant is both.
+///
+/// It bites soonest in the language this reader is written for: a Traditional
+/// Chinese passphrase is three bytes per character, so the limit lands at 24
+/// characters, well inside what someone might reasonably choose.
+///
+/// The crate offers `non_truncating_hash`/`non_truncating_verify`, which error
+/// instead. They are not used here because they reject a *72*-byte password too
+/// (the limit is exclusive there), and because rejecting at the prompt says more
+/// than an error at verification time can.
+pub const MAX_PASSWORD_BYTES: usize = 72;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,11 @@ use tracing_subscriber::{
 
 use comics::{
     APP_CSS, APP_JS, APPLE_TOUCH_ICON_PNG, AppState, AuthConfig, BCRYPT_COST, DEFAULT_ABSOLUTE_TTL,
-    DEFAULT_IDLE_TTL, FAVICON_PNG, FAVICON_SVG, RateLimiter, Secret, SessionAuditSalt,
-    SessionStore, THEME_JS, TrustedProxies, VERSION, auth_middleware_fn, csrf_origin_guard,
-    healthz_route, index_route, login_route, login_submit_route, logout_route, no_store_html,
-    rescan_books_route, scan_books, security_headers_layer, show_book_route, show_page_route,
-    show_thumb_route, shuffle_book_route, shuffle_route,
+    DEFAULT_IDLE_TTL, FAVICON_PNG, FAVICON_SVG, MAX_PASSWORD_BYTES, RateLimiter, Secret,
+    SessionAuditSalt, SessionStore, THEME_JS, TrustedProxies, VERSION, auth_middleware_fn,
+    csrf_origin_guard, healthz_route, index_route, login_route, login_submit_route, logout_route,
+    no_store_html, rescan_books_route, scan_books, security_headers_layer, show_book_route,
+    show_page_route, show_thumb_route, shuffle_book_route, shuffle_route,
 };
 
 // The release image links musl, whose default allocator is markedly slower than
@@ -400,11 +400,23 @@ async fn run_server(addr: SocketAddr, opts: &Opts) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Refusing an over-long password here rather than truncating it is the whole
+/// point: `bcrypt::hash` would accept it, print a hash, and leave the operator
+/// believing in a passphrase whose tail does nothing. See
+/// [`comics::MAX_PASSWORD_BYTES`].
 fn hash_password() -> anyhow::Result<()> {
     let password = rpassword::prompt_password("Password: ")?;
     let confirmation = rpassword::prompt_password("Confirmation: ")?;
     if password != confirmation {
         bail!("Password mismatch");
+    }
+    let len = password.len();
+    if len > MAX_PASSWORD_BYTES {
+        bail!(
+            "Password is {len} bytes, but bcrypt hashes only the first \
+             {MAX_PASSWORD_BYTES} and would discard the rest silently. \
+             Shorten it — note that non-ASCII characters cost several bytes each."
+        );
     }
     let hashed = bcrypt::hash(password, BCRYPT_COST)?;
     println!("{hashed}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,16 +400,16 @@ async fn run_server(addr: SocketAddr, opts: &Opts) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Refusing an over-long password here rather than truncating it is the whole
-/// point: `bcrypt::hash` would accept it, print a hash, and leave the operator
-/// believing in a passphrase whose tail does nothing. See
-/// [`comics::MAX_PASSWORD_BYTES`].
-fn hash_password() -> anyhow::Result<()> {
-    let password = rpassword::prompt_password("Password: ")?;
-    let confirmation = rpassword::prompt_password("Confirmation: ")?;
-    if password != confirmation {
-        bail!("Password mismatch");
-    }
+/// Refuse a password bcrypt would only partly hash.
+///
+/// Refusing rather than truncating is the whole point: `bcrypt::hash` accepts an
+/// over-long password, prints a hash, and leaves the operator believing in a
+/// passphrase whose tail does nothing. See [`comics::MAX_PASSWORD_BYTES`].
+///
+/// Split out of [`hash_password`] so it can be tested: that one reads from a tty
+/// and no test can drive it, which would leave the check below — the part that
+/// fails *silently* if it ever regresses — covered by nothing.
+fn ensure_password_fits(password: &str) -> anyhow::Result<()> {
     let len = password.len();
     if len > MAX_PASSWORD_BYTES {
         bail!(
@@ -418,6 +418,16 @@ fn hash_password() -> anyhow::Result<()> {
              Shorten it — note that non-ASCII characters cost several bytes each."
         );
     }
+    Ok(())
+}
+
+fn hash_password() -> anyhow::Result<()> {
+    let password = rpassword::prompt_password("Password: ")?;
+    let confirmation = rpassword::prompt_password("Confirmation: ")?;
+    if password != confirmation {
+        bail!("Password mismatch");
+    }
+    ensure_password_fits(&password)?;
     let hashed = bcrypt::hash(password, BCRYPT_COST)?;
     println!("{hashed}");
     Ok(())
@@ -528,10 +538,13 @@ async fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{LOGIN_MAX_ATTEMPTS, Opts, init_route, resolve_cookie_secure, spawn_initial_scan};
+    use crate::{
+        LOGIN_MAX_ATTEMPTS, Opts, ensure_password_fits, init_route, resolve_cookie_secure,
+        spawn_initial_scan,
+    };
     use axum_test::TestServer;
     use clap::Parser as _;
-    use comics::{BCRYPT_COST, VERSION};
+    use comics::{BCRYPT_COST, MAX_PASSWORD_BYTES, VERSION};
     use tokio::sync::oneshot;
 
     /// Fixed secret so the derived ID seed — and therefore the URLs below — are
@@ -885,6 +898,34 @@ mod tests {
     #[test]
     fn version_is_set() {
         assert!(!VERSION.is_empty());
+    }
+
+    /// The two lengths bcrypt still hashes in full. The second is the one worth
+    /// spelling out: `MAX_PASSWORD_BYTES` counts bytes, and a Traditional
+    /// Chinese passphrase costs three per character, so the ceiling is 24 of
+    /// them rather than 72.
+    #[test]
+    fn hash_password_accepts_a_password_at_the_limit() {
+        assert!(ensure_password_fits(&"x".repeat(MAX_PASSWORD_BYTES)).is_ok());
+        let cjk = "密".repeat(24);
+        assert_eq!(MAX_PASSWORD_BYTES, cjk.len());
+        assert!(ensure_password_fits(&cjk).is_ok());
+    }
+
+    /// Anything longer must be rejected outright rather than hashed to its first
+    /// 72 bytes, and the message must name the size that was submitted — the
+    /// operator cannot count the bytes of a passphrase they just typed blind.
+    #[test]
+    fn hash_password_refuses_what_bcrypt_would_truncate() {
+        let err = ensure_password_fits(&"x".repeat(MAX_PASSWORD_BYTES + 1))
+            .expect_err("73 bytes was accepted")
+            .to_string();
+        assert!(err.contains("73 bytes"), "{err}");
+
+        let err = ensure_password_fits(&"密".repeat(25))
+            .expect_err("75 bytes was accepted")
+            .to_string();
+        assert!(err.contains("75 bytes"), "{err}");
     }
 
     // Authentication: form login backed by a signed session cookie.


### PR DESCRIPTION
Two findings from a pass over the [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html).

## 1. The credential check short-circuited, so response time enumerated the username

`verify_credentials` was:

```rust
username == expected_user && bcrypt::verify(password, password_hash).unwrap_or(false)
```

`&&` short-circuits, so a wrong username never reached bcrypt. The response body and status were byte-identical either way, but the timing was not — this is the "quick exit" pattern the cheat sheet names under *Authentication and Error Messages*. The rate limiter caps an attacker at 5 attempts a minute, which bounds the rate but not the leak: one attempt is enough to read the difference.

Both halves are now computed unconditionally and combined with a bitwise `&` on `subtle::Choice`, which — unlike `&&` — is not a control-flow branch. The username is compared with `ConstantTimeEq` for the same reason at a smaller scale.

Measured on the old code by the new regression test:

```
a wrong username took 291ns against 16.295417ms for a wrong password
  — the credential check is short-circuiting
```

Five orders of magnitude, at cost 8; the configured `BCRYPT_COST` is 11.

## 2. Passwords over 72 bytes were silently truncated

bcrypt reads at most 72 bytes, and the crate's `hash`/`verify` drop the rest rather than erroring (`non_truncating_*` variants exist but reject a *72*-byte password too, since their limit is exclusive). Two consequences:

- `hash-password` accepted a long passphrase and printed a hash, leaving the operator believing in a secret whose tail does nothing.
- Every string sharing a 72-byte password's prefix verified against the same hash — the password plus *any* suffix was accepted.

The cheat sheet asks for the opposite ("Do not silently truncate passwords") and for a maximum input length on the comparison function. `MAX_PASSWORD_BYTES` is now enforced at both ends: `hash-password` refuses over-long input with a message naming the byte count, and `verify_credentials` refuses it before spending a verification on it.

The limit is counted in bytes, which bites soonest in the language this reader is written for: a Traditional Chinese passphrase is three bytes per character, so it lands at 24 characters, well inside what someone might reasonably choose.

## Dependency

`subtle` 2.6.1 was already in the tree as a `bcrypt` dependency; promoting it to a direct one adds no package and no transitive dependency. `Cargo.lock` changes by one line.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo deny check` — clean
- `cargo nextest run` — 187/187 pass
- The three new tests were confirmed to be genuine regression tests: reverting the logic to the old implementation fails all three (the timing figures above are from that run)
- `hash-password` driven through a pty end to end: 72 bytes ASCII and 24 CJK characters (exactly 72 bytes) hash successfully; 73 bytes and 25 CJK characters (75 bytes) exit 1 with the byte count in the message

## Not addressed

Two further gaps from the same review are deliberately left out of this PR: login throttling is keyed on source IP only, with no account-scoped counter (the cheat sheet asks for the latter), and `COMICS_AUTH_PASSWORD_HASH` is not validated at startup, so a malformed hash fails every login without a diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)